### PR TITLE
MemDB: Misc enhancements in preparation for multi-field indexes.

### DIFF
--- a/Common/MemDB/Ideas, and TODO.txt
+++ b/Common/MemDB/Ideas, and TODO.txt
@@ -1,21 +1,40 @@
 
 MemDB: TODO and notes.
 
+- Index metadata classes done.
+- Explicitly disallowed changing of objects (fields, indexes, foreign keys)
+  once created. Will solve altering objects via composite ops.
+
 1. Index on multiple fields.
 
-2. Remove stuff we're not gonna handle in the "lowest level" API.
-   - Change field type. Handle with composite ops?
-   - Any other index/field changes we don't currently support.
+(FK not allowed on multi-key index).
 
-3. Blob handling - do memcopies properly.
+2. Blob handling - do memcopies properly.
     Testapp for basic blob handling.
 
-4. Need a case insensitive comparison for string indexes.
+3. Need a case insensitive comparison for string indexes.
 
-5: Yeah, go,on. Allow a memcmp for indexing on blobs,
+(FK not allowed on case insensitive index).
+
+4. Yeah, go,on. Allow a memcmp for indexing on blobs,
      provided blobdata small (hash etc?).
 
-6. Composite ops.
+5. Composite ops.
+
+- Revisit the naming / renaming of entities indexes and fields
+  - Rename / rename clashes.
+  - Rename / delete clashes.
+  - Resolved same way at all levels?
+
+  - What is retryable?
+  - When things related, determining which changes are "real" changes,
+    and which are implicit renames as a result of other stuff going on.
+
+- Composite ops.
+  - Do some things (eg change field type?) with create and then
+    rename.
+  - How much can we solve things by creating new/old versions of things,
+    (indexes / fields / tables) and then renaming things around?
 
 6a. Support mini transactions and changesets
     - To Journal has optional inverse for all journalling funcs.
@@ -33,6 +52,12 @@ MemDB: TODO and notes.
 
     - Revisit all API functions with respect to which are auto-retryable
       after a mini-commit.
+
+      Types of conflicts to consider:
+      - Multiple renames. (Disallow after mini-commit implemented).
+      - Rename / delete conflicts (Disallow after mini-commit implemented).
+      - If implement change field type / change attrs / etc
+        - disallow changes if metadata changes already present?
 
     - Handling of mini-commit failure.
 

--- a/Common/MemDB/MemDBIndexing.pas
+++ b/Common/MemDB/MemDBIndexing.pas
@@ -323,6 +323,14 @@ begin
     begin
       if (TagData.MainIndexClass = micTemporary) then
       begin
+        //These field offsets look the wrong way around, but aren't.
+
+        //ExtraFieldOffset is the "higher" number when removing fields from the
+        //table. Not only does it correspond to the old index, (which you expect)
+
+        //it *also* corresponds to the new index, when the delete sentinels
+        //have not yet been removed.
+
         if UsingNextCopy then
           OwnFieldOffset := TagData.ExtraFieldOffset
         else
@@ -452,6 +460,14 @@ begin
     begin
       if (TagData.MainIndexClass = micTemporary) then
       begin
+        //These field offsets look the wrong way around, but aren't.
+
+        //ExtraFieldOffset is the "higher" number when removing fields from the
+        //table. Not only does it correspond to the old index, (which you expect)
+
+        //it *also* corresponds to the new index, when the delete sentinels
+        //have not yet been removed.
+
         if OtherUsingNextCopy then
           OtherFieldOffset := TagData.ExtraFieldOffset
         else

--- a/Common/MemDB/MemDBJournal.pas
+++ b/Common/MemDB/MemDBJournal.pas
@@ -192,8 +192,6 @@ const
   S_CORRUPTED_FILE = 'Corrupted file: ';
   S_EXCEPTION = 'Internal error, exception: ';
   S_STREAM_SYSTEM_INTERNAL = 'Stream system internal error writing to file.';
-  ONE_MEG = 1024*1024;
-  FILE_CACHE_SIZE = ONE_MEG; //Let's not mess about with small cache sizes.
 
 type
   TJournalFileType = (jftInitOrCheckpoint, jftIncremental);

--- a/Common/MemDB/MemDBMisc.pas
+++ b/Common/MemDB/MemDBMisc.pas
@@ -104,9 +104,6 @@ type
 
   procedure JoinLists(Joined, ToAppend: TList);
 
-  procedure ConvertField(const CurField: TMemDbFieldDataRec;
-                         var NextField: TMemDbFieldDataRec);
-
   function IsoToAB(Iso: TMDBIsolationLevel): TABSelection;
   function ABToSubIndexClass(AB: TABSelection): TSubIndexClass;
   function IsoToSubIndexClass(Iso: TMDBIsolationLevel): TSubIndexClass;
@@ -149,6 +146,9 @@ const
     ('Null', 'Initialising', 'Running',
     'Closing (WaitClients)', 'Closing (WaitPersist)', 'Closed',
     'Error');
+
+  ONE_MEG = 1024*1024;
+  FILE_CACHE_SIZE = ONE_MEG; //Let's not mess about with small cache sizes.
 
 type
 {$IFDEF USE_TRACKABLES}
@@ -514,7 +514,7 @@ end;
 constructor TMemDBWriteCachedFileStream.Create(const FileName: string);
 begin
   FFileName := FileName;
-  inherited Create(FileName);
+  inherited Create(FileName, FILE_CACHE_SIZE);
 {$IFOPT C+}
   FProxy := TTrackable.Create;
 {$ENDIF}
@@ -539,13 +539,6 @@ begin
   Joined.Count := JoinedCount + ToAppendCount;
   for i := JoinedCount to Pred(Joined.Count) do
     Joined.Items[i] := ToAppend.Items[i - JoinedCount];
-end;
-
-procedure ConvertField(const CurField: TMemDbFieldDataRec;
-                       var NextField: TMemDbFieldDataRec);
-begin
-  //TODO
-  raise EMemDBInternalException.Create(S_NOT_IMPLEMENTED);
 end;
 
 function IsoToAB(Iso: TMDBIsolationLevel): TABSelection;

--- a/Common/MemDB/Test/MemDBTest.dproj
+++ b/Common/MemDB/Test/MemDBTest.dproj
@@ -5,7 +5,7 @@
         <FrameworkType>FMX</FrameworkType>
         <MainSource>MemDBTest.dpr</MainSource>
         <Base>True</Base>
-        <Config Condition="'$(Config)'==''">Release</Config>
+        <Config Condition="'$(Config)'==''">Debug</Config>
         <Platform Condition="'$(Platform)'==''">Win64</Platform>
         <TargetedPlatforms>3</TargetedPlatforms>
         <AppType>Application</AppType>
@@ -88,6 +88,8 @@
         <DCC_UsePackage>bindcompfmx;DBXSqliteDriver;fmx;rtl;dbrtl;DbxClientDriver;IndySystem;TeeDB;bindcomp;vclib;DBXInterBaseDriver;Tee;DataSnapCommon;xmlrtl;ibxpress;DbxCommonDriver;vclimg;IndyProtocols;dbxcds;DBXMySQLDriver;MetropolisUILiveTile;vclactnband;bindengine;vcldb;soaprtl;bindcompdbx;vcldsnap;bindcompvcl;FMXTee;TeeUI;vclie;vcltouch;CustomIPTransport;vclribbon;VclSmp;dsnap;IndyIPServer;Intraweb;fmxase;vcl;IndyCore;IndyIPCommon;CloudService;dsnapcon;FmxTeeUI;inet;fmxobj;vclx;inetdbxpress;webdsnap;fmxdae;dbexpress;adortl;IndyIPClient;$(DCC_UsePackage)</DCC_UsePackage>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_1)'!=''">
+        <DCC_RangeChecking>true</DCC_RangeChecking>
+        <DCC_IntegerOverflowCheck>true</DCC_IntegerOverflowCheck>
         <VerInfo_Keys>CompanyName=;FileDescription=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=;ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
         <VerInfo_Locale>2057</VerInfo_Locale>
         <Manifest_File>None</Manifest_File>

--- a/Common/MemDB/Test/MemDBTestForm.pas
+++ b/Common/MemDB/Test/MemDBTestForm.pas
@@ -509,10 +509,10 @@ begin
   //Now delete all the rows.
   DelRows;
 
-  SetBaseRowSet;
-
   //Test 1.
   //Add rows satisfying FK relationship to both tables (Base row set).
+  SetBaseRowSet;
+
   //Add FK, check all OK.
   Trans := FSession.StartTransaction(amReadWrite);
   try
@@ -560,7 +560,7 @@ begin
     end;
   end;
 
-  //Add extra row in Referring, re-add FK
+  //Add extra row in Referring, re-add FK (all in same transaction).
   Pass := false;
   Trans := FSession.StartTransaction(amReadWrite);
   try
@@ -590,25 +590,23 @@ begin
     end;
     Pass := true;
     Trans.CommitAndFree;
-    ResMemo.Lines.Add('FK Test 1a, foreign key violation failed.');
+    ResMemo.Lines.Add('FK Test 1a, foreign key violation (same transaction) failed.');
   except
     on E: Exception do
     begin
       Trans.RollbackAndFree;
       if Pass then
-        ResMemo.Lines.Add('FK Test 1a, foreign key violation OK.')
+        ResMemo.Lines.Add('FK Test 1a, foreign key violation (same transaction) OK.')
       else
       begin
-        ResMemo.Lines.Add('FK Test 1a, foreign key violation failed.');
+        ResMemo.Lines.Add('FK Test 1a, foreign key violation (same transaction) failed.');
         raise;
       end;
     end;
   end;
 
-  //Check fails.
-
   //Test 1b.
-  //Remove row in master, re-add FK
+  //Remove row in master, re-add FK (all in same transaction)
   DelRows;
   SetBaseRowSet;
 
@@ -638,17 +636,17 @@ begin
     end;
     Pass := true;
     Trans.CommitAndFree;
-    ResMemo.Lines.Add('FK Test 1b, foreign key violation failed.');
+    ResMemo.Lines.Add('FK Test 1b, foreign key violation (same transaction) failed.');
   //Check fails.
   except
     on E: Exception do
     begin
       Trans.RollbackAndFree;
       if Pass then
-        ResMemo.Lines.Add('FK Test 1b, foreign key violation OK.')
+        ResMemo.Lines.Add('FK Test 1b, foreign key violation (same transaction) OK.')
       else
       begin
-        ResMemo.Lines.Add('FK Test 1b, foreign key violation failed.');
+        ResMemo.Lines.Add('FK Test 1b, foreign key violation (same transaction) failed.');
         raise;
       end;
     end;
@@ -710,17 +708,17 @@ begin
     end;
     Pass := true;
     Trans.CommitAndFree;
-    ResMemo.Lines.Add('FK Test 2a, foreign key violation failed.');
+    ResMemo.Lines.Add('FK Test 2a, foreign key violation (separate transaction) failed.');
   //Check fails.
   except
     on E: Exception do
     begin
       Trans.RollbackAndFree;
       if Pass then
-        ResMemo.Lines.Add('FK Test 2a, foreign key violation OK.')
+        ResMemo.Lines.Add('FK Test 2a, foreign key violation (separate transaction) OK.')
       else
       begin
-        ResMemo.Lines.Add('FK Test 2a, foreign key violation failed.');
+        ResMemo.Lines.Add('FK Test 2a, foreign key violation (separate transaction) failed.');
         raise;
       end;
     end;
@@ -747,17 +745,17 @@ begin
     end;
     Pass := true;
     Trans.CommitAndFree;
-    ResMemo.Lines.Add('FK Test 2b, foreign key violation failed.');
+    ResMemo.Lines.Add('FK Test 2b, foreign key violation (separate transaction) failed.');
   //Check fails.
   except
     on E: Exception do
     begin
       Trans.RollbackAndFree;
       if Pass then
-        ResMemo.Lines.Add('FK Test 2b, foreign key violation OK.')
+        ResMemo.Lines.Add('FK Test 2b, foreign key violation (separate transaction) OK.')
       else
       begin
-        ResMemo.Lines.Add('FK Test 2b, foreign key violation failed.');
+        ResMemo.Lines.Add('FK Test 2b, foreign key violation (separate transaction) failed.');
         raise;
       end;
     end;
@@ -788,17 +786,17 @@ begin
     end;
     Pass := true;
     Trans.CommitAndFree;
-    ResMemo.Lines.Add('FK Test 2c, foreign key violation failed.');
+    ResMemo.Lines.Add('FK Test 2c, foreign key violation (separate transaction) failed.');
   //Check fails.
   except
     on E: Exception do
     begin
       Trans.RollbackAndFree;
       if Pass then
-        ResMemo.Lines.Add('FK Test 2c, foreign key violation OK.')
+        ResMemo.Lines.Add('FK Test 2c, foreign key violation (separate transaction) OK.')
       else
       begin
-        ResMemo.Lines.Add('FK Test 2c, foreign key violation failed.');
+        ResMemo.Lines.Add('FK Test 2c, foreign key violation (separate transaction) failed.');
         raise;
       end;
     end;
@@ -828,17 +826,17 @@ begin
     end;
     Pass := true;
     Trans.CommitAndFree;
-    ResMemo.Lines.Add('FK Test 2d, foreign key violation failed.');
+    ResMemo.Lines.Add('FK Test 2d, foreign key violation (separate transaction) failed.');
   //Check fails.
   except
     on E: Exception do
     begin
       Trans.RollbackAndFree;
       if Pass then
-        ResMemo.Lines.Add('FK Test 2d, foreign key violation OK.')
+        ResMemo.Lines.Add('FK Test 2d, foreign key violation (separate transaction) OK.')
       else
       begin
-        ResMemo.Lines.Add('FK Test 2d, foreign key violation failed.');
+        ResMemo.Lines.Add('FK Test 2d, foreign key violation (separate transaction) failed.');
         raise;
       end;
     end;
@@ -918,7 +916,7 @@ begin
   //Field / index rearrangement and simul FK add/check.
 
   //Test 3a.
-  //Add extra fields to both tables.
+  //Add extra fields to both tables, in preparation for...
   //Dup row contents, add indexes, and add dup foreign key.
   //Check FK checking OK, even when index being added.
   Trans := FSession.StartTransaction(amReadWrite);
@@ -953,7 +951,9 @@ begin
   end;
 
   //Test 3b.
-  //Add indices, data and foreign key.
+  //Extra fields now added, so ...
+  //Dup row contents, add indexes, and add dup foreign key.
+  //Check FK checking OK, even when index being added.
   Trans := FSession.StartTransaction(amReadWrite);
   try
     DBAPI := Trans.GetAPI;

--- a/Overall TODO.txt
+++ b/Overall TODO.txt
@@ -2,36 +2,12 @@ Delphi TODO.
 
 Then: MemDB changes.
 
-0: Indexing: Index on multiple fields.
+1: MemDB Index on multiple fields.
 
-1. See if we can address DB load times / index parallelism any better.
-2. Niceties to do with starting / ending transactions.
-3. Multi-changeset transactions:
- - Requires changeset inverses, and auto "new changeset in stransaction".
- - Specific exception to indicate new changeset required, preceeding code
-   side-effect free, then re-run required API from the top?
+2. Load times.
 
- - Multi changeset commit and rollback.
- - Changes to persistence. Try to keep backward compatible if possible.
+3. Composite ops.
 
- 4. Query engine. Not even sure where to start here.
 
-Things to re-remember in MemDB.
 
-1. Index changesets.
-2. NDIndex indexes to real IndexIndexes.
-3. ictTemporary in index tags. Where used, why? How does it affect the field of the index?
-   Temporary indicating index is changing, or fields index underneath is changing?
-4. Two trees for each index, with current / next? Remember how that works.
-
-Things to re-discover in MemDB:
-  - How many points where we had to "back out / stop" further changes, because
-    getting to the edge of allowable concurrent changes:
-    - Rename conflicts.
-    - Delete after add.
-    - Table structure changes.
-    - How are we going to deal with them?
-
-Having re-remembered that, look at Foreign key stuff.
-  - Will it go FUBAR if we index on multiple fields?
 


### PR DESCRIPTION
MemDB: Update TODO, re-enable parallel index build.
MemDB: Explicitly check indexes and fields underlying FK are constant (this was implicit previously).
MemDB: Explicitly disallow change field type or index attrs after creation.
Misc: Update TODO's and project files.
MemDB: Relax tag checking in release build, fix compiler warnings.
MemDB: Update TODO.
MemDB: Increase cached temp stream size. Relax index checks for moved fields.
MemDB: Refactor checking for streamed in row indexing.
MemDB: Remove field index from index def. Some validation funcs need refactor.
MemDB: Change TagDataArray to TagDataList (cleaner code).