### PR TITLE
MemDB: Further startup optimizations.

### DIFF
--- a/Common/MemDB/MemDBJournal.pas
+++ b/Common/MemDB/MemDBJournal.pas
@@ -193,6 +193,8 @@ const
   S_EXCEPTION = 'Internal error, exception: ';
   S_STREAM_SYSTEM_INTERNAL = 'Stream system internal error writing to file.';
 
+  CHECKPOINT_RATIO = 10; { More than 1/10th data in journal, re-checkpoint }
+
 type
   TJournalFileType = (jftInitOrCheckpoint, jftIncremental);
   TJournalFileExts = array[TJournalFileType] of string;
@@ -811,7 +813,7 @@ begin
     CreateCheckpoint :=
          (not AnyFiles)
       or
-         ((TotalIncrFileSize > (TotalInitFileSize div 2))
+         ((TotalIncrFileSize > (TotalInitFileSize div CHECKPOINT_RATIO))
          and (TotalIncrFileSize > ONE_MEG))
       or (ReadFileCount > MAX_INCR_JOURNAL_FILES);
     result := true;

--- a/Common/MemDB/Test/MemDBTest.dproj
+++ b/Common/MemDB/Test/MemDBTest.dproj
@@ -117,10 +117,12 @@
         <DCC_SymbolReferenceInfo>0</DCC_SymbolReferenceInfo>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_2_Win32)'!=''">
+        <DCC_IOChecking>false</DCC_IOChecking>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
         <VerInfo_Locale>1033</VerInfo_Locale>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_2_Win64)'!=''">
+        <DCC_IOChecking>false</DCC_IOChecking>
         <DCC_DebugInfoInExe>true</DCC_DebugInfoInExe>
         <DCC_RemoteDebug>true</DCC_RemoteDebug>
         <DCC_MapFile>3</DCC_MapFile>
@@ -151,6 +153,7 @@
         <DCCReference Include="..\..\Parallelizer\Parallelizer.pas"/>
         <DCCReference Include="..\..\NullStream\NullStream.pas"/>
         <None Include="..\Ideas, and TODO.txt"/>
+        <None Include="Performance figures.txt"/>
         <BuildConfiguration Include="Release">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>

--- a/Common/MemDB/Test/MemDBTestForm.pas
+++ b/Common/MemDB/Test/MemDBTestForm.pas
@@ -353,6 +353,7 @@ var
   Data: TMemDBFieldDataRec;
 
 begin
+  FTimeStamp := Now;
   Trans := FSession.StartTransaction(amReadWrite);
   try
     DBAPI := Trans.GetAPI;


### PR DESCRIPTION
MemDB: More agressive checkpointing
MemDB: Don't need another test set for opts, can change opts in code and retest.
MemDB: Validate indexes in parallel too.
MemDB: Slightly more agressive first xaction optimization. MemDB: Remove original first xation optimization.