### PR TITLE
MemDB2: Internals now up to speed (node caching). User ops, not so much.

### DIFF
--- a/Common/Indexed Store/IndexedStore.pas
+++ b/Common/Indexed Store/IndexedStore.pas
@@ -92,11 +92,6 @@ type
     function CompareItems(OwnItem, OtherItem: TObject; IndexTag: TTagType; OtherNode: TIndexNode): integer; virtual;
       abstract;
   public
-{$IFOPT C+}
-    class function ComparePointers(Own, Other: Pointer): integer;
-{$ELSE}
-    class function ComparePointers(Own, Other: Pointer): integer; inline;
-{$ENDIF}
     constructor Create; virtual;
   end;
   TIndexNodeClass = class of TIndexNode;
@@ -336,6 +331,8 @@ type
     property SearchVal: TObject read FSearchVal write FSearchVal;
   end;
 
+  function ComparePointers(Own, Other: Pointer): integer;
+
 implementation
 
 uses SysUtils, LockAbstractions;
@@ -412,6 +409,42 @@ const
     'Store found an index link node, but it was not attached to an index node.';
   S_NO_MEM_FORWARDED =
     'Out of memory exception forwarded from client thread';
+
+{ Misc functions }
+
+{$HINTS OFF}
+function ComparePointers(Own, Other: Pointer): integer;
+var
+  OwnInt, OtherInt: Cardinal;
+  Own64, Other64: UInt64;
+begin
+  if sizeof(Pointer) = sizeof(Cardinal) then
+  begin
+    OwnInt := Cardinal(Own);
+    OtherInt := Cardinal(Other);
+    if OtherInt > OwnInt then
+      result := 1
+    else if OtherInt < OwnInt then
+      result := -1
+    else
+      result := 0;
+  end
+  else if sizeof(Pointer) = sizeof(UInt64) then
+  begin
+    Own64 := UInt64(Own);
+    Other64 := UInt64(Other);
+    if Other64 > Own64 then
+      result := 1
+    else if Other64 < Own64 then
+      result := -1
+    else
+      result := 0;
+  end
+  else
+    Assert(false);
+end;
+{$HINTS ON}
+
 
 (************************************
  * TItemRec                         *
@@ -1668,39 +1701,6 @@ begin
   //Need this constructor, because virtual,
   //because variable class type creation used here.
 end;
-
-{$HINTS OFF}
-class function TIndexNode.ComparePointers(Own, Other: Pointer): integer;
-var
-  OwnInt, OtherInt: Cardinal;
-  Own64, Other64: UInt64;
-begin
-  if sizeof(Pointer) = sizeof(Cardinal) then
-  begin
-    OwnInt := Cardinal(Own);
-    OtherInt := Cardinal(Other);
-    if OtherInt > OwnInt then
-      result := 1
-    else if OtherInt < OwnInt then
-      result := -1
-    else
-      result := 0;
-  end
-  else if sizeof(Pointer) = sizeof(UInt64) then
-  begin
-    Own64 := UInt64(Own);
-    Other64 := UInt64(Other);
-    if Other64 > Own64 then
-      result := 1
-    else if Other64 < Own64 then
-      result := -1
-    else
-      result := 0;
-  end
-  else
-    Assert(false, S_POINTERS_ODD_SIZE);
-end;
-{$HINTS ON}
 
 function TIndexNode.Compare(Other: TBinTreeItem; AllowKeyDedupe: boolean): integer;
 var

--- a/Common/MemDB2/MemDB2.pas
+++ b/Common/MemDB2/MemDB2.pas
@@ -42,6 +42,16 @@ type
 
   TInProgressType = (tiptNone, tiptCommitRollback);
 
+  //Currently used for garbage collection from multiple async/parallel operations.
+  TXEntityLocalContext = class(TTXLocalContext)
+    FLocalLock: TCriticalSection;
+    //In future perhaps have separate lists of TObject and TReffed.
+    FCacheList: TList;
+    procedure AddCache(Cache: TObject);
+    constructor Create;
+    destructor Destroy; override;
+  end;
+
 {$IFDEF USE_TRACKABLES}
   TMemDBTransaction = class(TTrackedReffed)
 {$ELSE}
@@ -63,6 +73,7 @@ type
     FApiObjects: TList;
     FApiObjectLock: TCriticalSection;
     FCRInterface: TMemAPIDatabaseInternal;
+    FLocalContext: TXEntityLocalContext;
   protected
   public
     procedure CommitAndFree;
@@ -88,6 +99,7 @@ type
     property ParentSession: TMemDBSession read FSession;
     property Changeset: TStream read FChangeset;
     property Session: TMemDBSession read FSession;
+    property LocalContext: TXEntityLocalContext read FLocalContext;
   end;
 
   //TODO - Might like to think about whether we actually need a session
@@ -198,6 +210,43 @@ const
   S_READONLY_HAS_CHANGED_DATA = 'Read-only transaction has changed data!';
   S_TRANSACTION_HAS_API_OBJECTS = 'Transaction has associated API objects. You should have freed them before commit/rollback';
 
+  { TXLocalContext }
+
+constructor TXEntityLocalContext.Create;
+begin
+  inherited;
+  FLocalLock := TCriticalSection.Create;
+  FCacheList := TList.Create;
+  //Set this way early so as little alloc as possible on rollback path.
+  FCacheList.Capacity := 64;
+end;
+
+destructor TXEntityLocalContext.Destroy;
+var
+  i: integer;
+begin
+  //Expect transaction synchronous cleanup to have already cleaned most of this
+  //up, but just in case...
+  for i := 0 to Pred(FCacheList.Count) do
+    TObject(FCacheList[i]).Free;
+  FCacheList.Free;
+  FLocalLock.Free;
+  inherited;
+end;
+
+procedure TXEntityLocalContext.AddCache(Cache: TObject);
+begin
+  if Assigned(Cache) then
+  begin
+    FLocalLock.Acquire;
+    try
+      FCacheList.Add(Cache);
+    finally
+      FLocalLock.Release;
+    end;
+  end;
+end;
+
   { TMemDBTransaction }
 
 function TMemDBTransaction.GetAPI: TMemAPIDatabase;
@@ -222,7 +271,7 @@ begin
   inherited;
   FApiObjects := TList.Create;
   FApiObjectLock := TCriticalSection.Create;
-  //No Add-Ref, initial refcount 1.
+  FLocalContext := TXEntityLocalContext.Create;
 end;
 
 procedure TMemDbTransaction.RegisterCreatedApi(Api: TMemDBApi);
@@ -303,6 +352,7 @@ begin
   Assert((not Assigned(FApiObjects)) or (FAPIObjects.Count = 0));
   FApiObjects.Free;
   FApiObjectLock.Free;
+  FLocalContext.Free;
   inherited;
 end;
 
@@ -960,6 +1010,7 @@ var
   ChangesetStream: TStream;
   TmpName: string;
   PseudoTid: TTransactionId;
+  Ctxt: TXEntityLocalContext;
 begin
   FSessionLock.Acquire;
   try
@@ -979,36 +1030,41 @@ begin
     //Totally consistent worldview - but will do list atomicity
     //inside DB classes as well.
     try
-      TmpName := TPath.GetTempFileName();
-      ChangesetStream := TMemDBTempFileStream.Create(TmpName);
-      PseudoTid := TTransactionId.NewTransactionID(ilSerialisable); //if no writes, should definitley be serialisable.
+      Ctxt := TXEntityLocalContext.Create;
       try
-        FDatabase.StartTransaction(PseudoTid);
-        FDatabase.CommitLock.Acquire; //This if we don't acquire at lrSharedRead for ever.
+        TmpName := TPath.GetTempFileName();
+        ChangesetStream := TMemDBTempFileStream.Create(TmpName);
+        PseudoTid := TTransactionId.NewTransactionID(ilSerialisable); //if no writes, should definitley be serialisable.
         try
+          FDatabase.StartTransaction(PseudoTid);
+          FDatabase.CommitLock.Acquire; //This if we don't acquire at lrSharedRead for ever.
           try
-            FDatabase.ToScratch(PseudoTid, ChangesetStream);
-          finally
-            //We probably shouldn't need to to this at all, but keep
-            //it here for safety.
-            FDatabase.MetaIndexLock.Acquire;
             try
-              FDatabase.Rollback(PseudoTid, rbpIndexRollback, []);
-              FDatabase.Rollback(PseudoTid, rbpMetaRollback, []);
+              FDatabase.ToScratch(PseudoTid, ChangesetStream);
             finally
-              FDatabase.MetaIndexLock.Release;
+              //We probably shouldn't need to to this at all, but keep
+              //it here for safety.
+              FDatabase.MetaIndexLock.Acquire;
+              try
+                FDatabase.Rollback(PseudoTid, rbpIndexRollback, [], Ctxt);
+                FDatabase.Rollback(PseudoTid, rbpMetaRollback, [], Ctxt);
+              finally
+                FDatabase.MetaIndexLock.Release;
+              end;
             end;
+          finally
+            FDatabase.CommitLock.Release;
+            FDatabase.Rollback(PseudoTid, rbpDelayedRollback, CleardownOptSet, Ctxt);
           end;
-        finally
-          FDatabase.CommitLock.Release;
-          FDatabase.Rollback(PseudoTid, rbpDelayedRollback, CleardownOptSet);
+        except
+          ChangesetStream.Free;
+          DeleteFile(TmpName);
+          raise;
         end;
-      except
-        ChangesetStream.Free;
-        DeleteFile(TmpName);
-        raise;
+        FJournal.Checkpoint(ChangesetStream);
+      finally
+        Ctxt.Free;
       end;
-      FJournal.Checkpoint(ChangesetStream);
     finally
       FRWWLock.Release(lrSharedRead);
       FSessionLock.Acquire;

--- a/Common/MemDB2/MemDB2Api.pas
+++ b/Common/MemDB2/MemDB2Api.pas
@@ -391,42 +391,50 @@ procedure TMemAPIDatabaseInternal.JournalReplayCycle(JournalEntry: TStream; Init
 var
    PseudoTid: TTransactionId;
    OptSet: TOptimizeSet;
+   SizeHint: TDBSizeHint;
+   Ctxt: TXEntityLocalContext;
 begin
-  OptSet := MakeOptimizationSet(DB.Policies, Initial, not Initial, false, 0, JournalEntry.Size);
+  FillChar(SizeHint, sizeof(SizeHint), 0);
+  OptSet := MakeOptimizationSet(DB.Policies, Initial, not Initial, false, SizeHint, JournalEntry.Size);
 
   PseudoTid := TTransactionId.NewTransactionID(ilSerialisable); //if only writer, should be serialisable.
+  Ctxt := TXEntityLocalContext.Create;
   try
-    DB.StartTransaction(PseudoTid);
+    try
+      DB.StartTransaction(PseudoTid);
 
-    Assert(not DB.AnyChanges(PseudoTid));
-    if Initial then
-      DB.FromScratch(PseudoTid, JournalEntry, OptSet)
-    else
-      DB.FromJournal(PseudoTid, JournalEntry);
+      Assert(not DB.AnyChanges(PseudoTid));
+      if Initial then
+        DB.FromScratch(PseudoTid, JournalEntry, OptSet)
+      else
+        DB.FromJournal(PseudoTid, JournalEntry);
 
-    DB.Prepare(PseudoTid, OptSet, Initial);
+      DB.Prepare(PseudoTid, OptSet, Initial);
 
-    DB.PreCommit(PseudoTid, pcpTables, OptSet);
-    DB.PreCommit(PseudoTid, pcpFKeys, OptSet);
-    DB.Commit(PseudoTid, ccpData, OptSet);
-    DB.Commit(PseudoTid, ccpMetaIndex, OptSet);
-    DB.Commit(PseudoTid, ccpCleardown, OptSet);
-  except
-    //Clear pins etc, although in this case, it's
-    //a non-start for the database.
-    //However, final deletion of entities should still work
-    //and delete everything provided we clear the pins.
-    DB.Rollback(PseudoTid, rbpIndexRollback, OptSet);
-    DB.Rollback(PseudoTid, rbpMetaRollback, []);
-    DB.Rollback(PseudoTid, rbpDelayedRollback, OptSet);
-    raise;
+      DB.PreCommit(PseudoTid, pcpTables, OptSet);
+      DB.PreCommit(PseudoTid, pcpFKeys, OptSet);
+      DB.Commit(PseudoTid, ccpData, OptSet, Ctxt);
+      DB.Commit(PseudoTid, ccpMetaIndex, OptSet, Ctxt);
+      DB.Commit(PseudoTid, ccpCleardown, OptSet, Ctxt);
+    except
+      //Clear pins etc, although in this case, it's
+      //a non-start for the database.
+      //However, final deletion of entities should still work
+      //and delete everything provided we clear the pins.
+      DB.Rollback(PseudoTid, rbpIndexRollback, OptSet, Ctxt);
+      DB.Rollback(PseudoTid, rbpMetaRollback, [], Ctxt);
+      DB.Rollback(PseudoTid, rbpDelayedRollback, OptSet, Ctxt);
+      raise;
+    end;
+  finally
+    Ctxt.Free;
   end;
 end;
 
 function TMemAPIDatabaseInternal.UserCommitCycle: TStream;
 var
   T: TMemDBTransaction;
-  SizeHint: int64;
+  SizeHint: TDBSizeHint;
   OptSet: TOptimizeSet;
 begin
   T := FAssociatedTransaction as TMemDBTransaction;
@@ -434,8 +442,12 @@ begin
   Assert(not Assigned(T.Changeset));
   result := MakeStream(T.Session.TempStorageMode);
   try
+    FillChar(SizeHint, sizeof(SizeHint), 0);
+    SizeHint.ShouldUpdateLayout := true;
     DB.SizeHint(T.Tid, SizeHint);
     OptSet := MakeOptimizationSet(DB.Policies, false, false, true, SizeHint, 0);
+    if T.LocalContext.FCacheList.Capacity < SizeHint.TotalIndexes then
+      T.LocalContext.FCacheList.Capacity := SizeHint.TotalIndexes;
 
     DB.Prepare(T.Tid, OptSet,false);
 
@@ -450,10 +462,10 @@ begin
         //The assumption is all exceptions raised in pre-commit.
         //We're not checking for errors or allocating memory by the time
         //it comes to the commit step.
-        DB.Commit(T.Tid, ccpData, OptSet);
+        DB.Commit(T.Tid, ccpData, OptSet, T.LocalContext);
         DB.MetaIndexLock.Acquire;
         try
-          DB.Commit(T.Tid, ccpMetaIndex, OptSet);
+          DB.Commit(T.Tid, ccpMetaIndex, OptSet, T.LocalContext);
         finally
           DB.MetaIndexLock.Release;
         end;
@@ -462,7 +474,7 @@ begin
         //temp indexes protected under commit lock.
         DB.MetaIndexLock.Acquire;
         try
-          DB.Rollback(T.Tid, rbpIndexRollback, OptSet);
+          DB.Rollback(T.Tid, rbpIndexRollback, OptSet, T.LocalContext);
         finally
           DB.MetaIndexLock.Release;
         end;
@@ -472,7 +484,7 @@ begin
       DB.CommitLock.Release;
     end;
     //Note final cleanup outside commit lock.
-    DB.Commit(T.Tid, ccpCleardown, OptSet);
+    DB.Commit(T.Tid, ccpCleardown, OptSet, T.LocalContext);
   except
     result.Free;
     raise; //Rely on later rollback etc to clear pins and such.
@@ -482,25 +494,26 @@ end;
 procedure TMemAPIDatabaseInternal.UserRollbackCycle;
 var
   T: TMemDBTransaction;
-  SizeHint: int64;
+  SizeHint: TDBSizeHint;
   OptSet: TOptimizeSet;
 
 begin
   T := FAssociatedTransaction as TMemDBTransaction;
   Assert(Assigned(T));
 
+  FillChar(SizeHint, sizeof(SizeHint), 0);
   DB.SizeHint(T.Tid, SizeHint);
   OptSet := MakeOptimizationSet(DB.Policies, false, false, true, SizeHint, 0);
 
   DB.MetaIndexLock.Acquire;
   try
-    DB.Rollback(T.Tid, rbpMetaRollback, []);
+    DB.Rollback(T.Tid, rbpMetaRollback, OptSet, T.LocalContext);
   finally
     DB.MetaIndexLock.Release;
   end;
   //OK to rollback general double buffered outside lock:
   //we know changes won't be committed to current world-view.
-  DB.Rollback(T.Tid, rbpDelayedRollback, OptSet);
+  DB.Rollback(T.Tid, rbpDelayedRollback, OptSet, T.LocalContext);
 end;
 
 { TMemAPIDatabase }

--- a/Common/MemDB2/MemDB2BufBase.pas
+++ b/Common/MemDB2/MemDB2BufBase.pas
@@ -77,6 +77,13 @@ type
   TMemDBCommitPhase = (ccpData, ccpMetaIndex, ccpCleardown);
   TMemDBRollbackPhase = (rbpIndexRollback, rbpMetaRollback, rbpDelayedRollback);
 
+{$IFDEF USE_TRACKABLES}
+  TTXLocalContext = class(TTrackable)
+{$ELSE}
+  TTXLocalContext = class
+{$ENDIF}
+  end;
+
   //Object which can write changes between current and next version to journal.
 {$IFDEF USE_TRACKABLES}
   TMemDBJournalCreator = class(TTrackable)
@@ -108,9 +115,9 @@ type
     //Check A/B buffered changes consistent and logical (and/or atomic) before commit.
     procedure PreCommit(const TId: TTransactionId; Phase: TMemDBPreCommitPhase; Opts:TOptimizeSet); virtual; abstract;
     //Save to journal / Make the changes.
-    procedure Commit(const TId: TTransactionId; Phase: TMemDBCommitPhase; Opts:TOptimizeSet); virtual; abstract;
+    procedure Commit(const TId: TTransactionId; Phase: TMemDBCommitPhase; Opts:TOptimizeSet; Ctxt: TTXLocalContext); virtual; abstract;
     //Rollback changes, possibly promptly or delayed.
-    procedure Rollback(const TId: TTransactionId; Phase: TMemDBRollbackPhase; Opts:TOptimizeSet); virtual; abstract;
+    procedure Rollback(const TId: TTransactionId; Phase: TMemDBRollbackPhase; Opts:TOptimizeSet; Ctxt: TTXLocalContext); virtual; abstract;
   end;
 
   //Generally deep clone unless some list magic requires otherwise.
@@ -255,22 +262,23 @@ type
   PMemDBIndexPin = ^TMemDbIndexPin;
 {$ENDIF}
 
-const
-  PIN_CACHE_SIZE = 64;  //Longest possible path + rebalances
-
 type
 {$IFDEF USE_TRACKABLES}
-  TMemDBPinCache = class(TTrackable)
+  TMemDBIPinCache = class(TTrackable)
 {$ELSE}
-  TMemDBPinCache = class
+  TMemDBIPinCache = class
 {$ENDIF}
   protected
     FPtrs: TList;
+    function GetCapacity: integer;
+    procedure SetCapacity(Capacity: integer);
   public
     constructor Create;
     destructor Destroy; override;
     function GetFromCache: PMemDBIndexPin;
     function PutToCache(Pin: PMemDBIndexPin): boolean;
+    procedure TakeNodesFrom(Cache: TMemDBIPinCache);
+    property Capacity: integer read GetCapacity write SetCapacity;
   end;
 
   TPinReason = (pinEvolve, pinFinalCheck);
@@ -327,7 +335,7 @@ type
     procedure SetListCreateClass(New: TMemDBStreamableClass);
 
     function HoldIndexPinInLock(Pin: PMemDbIndexPin): PMemDBIndexPin;
-    procedure ReleaseIndexPinOutsideLock(Pin: PMemDbIndexPin);
+    procedure ReleaseIndexPinOutsideLock(Pin: PMemDbIndexPin; NodeCacheHint: TMemDBNodeCache);
   public
     //Determining changes for Tid's is easy to do for composite objects,
     //if you don't mind accruing pins along the way (internal structure).
@@ -367,8 +375,8 @@ type
     procedure FromScratch(const PseudoTid: TTransactionId; Stream: TStream; Opts:TOptimizeSet);override;
 
     procedure PreCommit(const TId: TTransactionId; Phase: TMemDBPreCommitPhase; Opts:TOptimizeSet); override;
-    procedure Commit(const TId: TTransactionId; Phase: TMemDBCommitPhase; Opts:TOptimizeSet); override;
-    procedure Rollback(const TId: TTransactionId; Phase: TMemDBRollbackPhase;  Opts:TOptimizeSet); override;
+    procedure Commit(const TId: TTransactionId; Phase: TMemDBCommitPhase; Opts:TOptimizeSet; Ctxt: TTXLocalContext); override;
+    procedure Rollback(const TId: TTransactionId; Phase: TMemDBRollbackPhase;  Opts:TOptimizeSet; Ctxt: TTXLocalContext); override;
 
     //Navigated to via row list.
     function PinForCursor(const Tid: TTransactionId): boolean;
@@ -411,8 +419,8 @@ type
     //Node refcount > 0 means potentially shared in tree, but
     //once it's down to zero, we can used stack-passed thread-local caches to
     //speed things up considerably.
-    procedure UnpinFromIndex(IndexNode: TMemDbIndexLeafGeneric; PCache: TMemDBPinCache);
-    procedure DupIndexPin(SourceNode, DestNode: TMemDBIndexLeafGeneric; PCache: TMemDBPinCache);
+    procedure UnpinFromIndex(IndexNode: TMemDbIndexLeafGeneric; PCache: TMemDBIPinCache);
+    procedure DupIndexPin(SourceNode, DestNode: TMemDBIndexLeafGeneric; PCache: TMemDBIPinCache);
   end;
 
   TMemDBMultiBufferedTiny = class(TMemDbMultiBuffered)
@@ -451,7 +459,7 @@ type
 implementation
 
 uses
-  SysUtils, Reffed;
+  SysUtils, Reffed, IndexedStore;
 
 const
   S_CHANGESET_BAD_LISTS = 'Changeset has lists of items that are not consistent';
@@ -555,26 +563,28 @@ begin
 {$ENDIF}
 end;
 
-{ TMemDBPinCache }
+{ TMemDBIPinCache }
 
 
-constructor TMemDBPinCache.Create;
+constructor TMemDBIPinCache.Create;
 begin
   inherited;
   FPtrs := TList.Create;
+  FPtrs.Capacity := SMALL_NODE_PIN_CACHE_SIZE;
 end;
 
-destructor TMemDBPinCache.Destroy;
+destructor TMemDBIPinCache.Destroy;
 var
   i: integer;
 begin
+  FPtrs.Sort(ComparePointers);
   for i := 0 to Pred(FPtrs.Count) do
     DisposeIndexPin(PMemDBIndexPin(FPtrs[i]));
   FPtrs.Free;
   inherited;
 end;
 
-function TMemDBPinCache.GetFromCache: PMemDBIndexPin;
+function TMemDBIPinCache.GetFromCache: PMemDBIndexPin;
 var
   Count: integer;
 begin
@@ -589,14 +599,14 @@ begin
     result := nil;
 end;
 
-function TMemDBPinCache.PutToCache(Pin: PMemDBIndexPin): boolean;
+function TMemDBIPinCache.PutToCache(Pin: PMemDBIndexPin): boolean;
 var
   Count: integer;
 begin
   if Assigned(Pin) then
   begin
     Count := FPtrs.Count;
-    if Count < PIN_CACHE_SIZE then
+    if Count < FPtrs.Capacity then
     begin
       FPtrs.Add(Pin);
       ResetIndexPin(Pin);
@@ -607,6 +617,26 @@ begin
   end
   else
     result := true;
+end;
+
+procedure TMemDBIPinCache.TakeNodesFrom(Cache: TMemDBIPinCache);
+var
+  i: integer;
+begin
+  for i := 0 to Pred(Cache.FPtrs.Count) do
+    FPtrs.Add(Cache.FPtrs[i]);
+  Cache.FPtrs.Clear;
+end;
+
+function TMemDBIPinCache.GetCapacity: integer;
+begin
+  result := FPtrs.Capacity;
+end;
+
+procedure TMemDBIPinCache.SetCapacity(Capacity: integer);
+begin
+  Assert(Capacity >= FPtrs.Count);
+  FPtrs.Capacity := Capacity;
 end;
 
 { TMemDBJournalCreator }
@@ -1215,7 +1245,7 @@ begin
   end;
 end;
 
-procedure TMemDBMultiBuffered.Commit(const TId: TTransactionId; Phase: TMemDBCommitPhase; Opts:TOptimizeSet);
+procedure TMemDBMultiBuffered.Commit(const TId: TTransactionId; Phase: TMemDBCommitPhase; Opts:TOptimizeSet; Ctxt: TTXLocalContext);
 var
   Cur, Nxt: PMemDbMultiItem;
   Pin: PMemDbPinnedItem;
@@ -1291,7 +1321,7 @@ begin
   DCPLazyHandle(RefUp);
 end;
 
-procedure TMemDBMultiBuffered.Rollback(const Tid: TTransactionId; Phase: TMemDBRollbackPhase; Opts:TOptimizeSet);
+procedure TMemDBMultiBuffered.Rollback(const Tid: TTransactionId; Phase: TMemDBRollbackPhase; Opts:TOptimizeSet; Ctxt: TTXLocalContext);
 var
   Nxt: PMemDBMultiItem;
   Pin: PMemDbPinnedItem;
@@ -1556,7 +1586,7 @@ begin
   DCPLazyHandle(RefUp);
 end;
 
-procedure TMemDBMultiBuffered.DupIndexPin(SourceNode, DestNode: TMemDBIndexLeafGeneric; PCache: TMemDBPinCache);
+procedure TMemDBMultiBuffered.DupIndexPin(SourceNode, DestNode: TMemDBIndexLeafGeneric; PCache: TMemDBIPinCache);
 var
   RefUp: TReferenceUpdate;
   Pin, NewPin: PMemDBIndexPin;
@@ -1606,7 +1636,7 @@ begin
 end;
 
 
-procedure TMemDBMultiBuffered.UnpinFromIndex(IndexNode: TMemDbIndexLeafGeneric; PCache: TMemDBPinCache);
+procedure TMemDBMultiBuffered.UnpinFromIndex(IndexNode: TMemDbIndexLeafGeneric; PCache: TMemDBIPinCache);
 var
   RefUp: TReferenceUpdate;
   Pin: PMemDBIndexPin;
@@ -1655,13 +1685,13 @@ end;
 
 //N.B Must be careful to hold/release in pairs, because it releases INode
 //without further ado.
-procedure TMemDBMultiBuffered.ReleaseIndexPinOutsideLock(Pin: PMemDbIndexPin);
+procedure TMemDBMultiBuffered.ReleaseIndexPinOutsideLock(Pin: PMemDbIndexPin; NodeCacheHint: TMemDBNodeCache);
 begin
   //No UnpinFromIndex should have happened if we AddReffed OK.
   if Assigned(Pin) then
   begin
     Assert(Assigned(Pin.INode));
-    Pin.INode.Release; //Should call through to UnPinFromIndex.
+    Pin.INode.ReleaseToCache(NodeCacheHint); //Should call through to UnPinFromIndex.
   end;
 end;
 

--- a/Common/MemDB2/MemDB2Buffered.pas
+++ b/Common/MemDB2/MemDB2Buffered.pas
@@ -229,12 +229,12 @@ type
     procedure META_RequestChange(const Tid: TTransactionId); virtual;
     procedure META_Delete(const Tid: TTransactionId); virtual;
 
-    procedure SizeHint(const Tid: TTransactionId; var SizeHint: int64); virtual;
+    procedure SizeHint(const Tid: TTransactionId; var SizeHint: TDBSizeHint); virtual;
     procedure StartTransaction(const Tid: TTransactionId); virtual;
     procedure Prepare(const Tid: TTransactionId; Opts:TOptimizeSet; FromScratch: boolean); virtual;
     procedure PreCommit(const TId: TTransactionId; Phase: TMemDBPreCommitPhase; Opts:TOptimizeSet); override;
-    procedure Commit(const TId: TTransactionId; Phase: TMemDBCommitPhase; Opts:TOptimizeSet); override;
-    procedure Rollback(const TId: TTransactionId; Phase: TMemDBRollbackPhase; Opts:TOptimizeSet); override;
+    procedure Commit(const TId: TTransactionId; Phase: TMemDBCommitPhase; Opts:TOptimizeSet; Ctxt: TTXLocalContext); override;
+    procedure Rollback(const TId: TTransactionId; Phase: TMemDBRollbackPhase; Opts:TOptimizeSet; Ctxt: TTXLocalContext); override;
 
     procedure Init(const Tid: TTransactionId; Parent: TObject; Name:string; DSName: boolean);
 
@@ -297,6 +297,7 @@ type
     function AnyChanges(const Tid:TTransactionId): boolean; override;
     function AnyChangesForTid(const Tid: TTransactionId): boolean; override;
 
+    procedure SizeHint(const Tid: TTransactionId; var SizeHint: TDBSizeHint); override;
     procedure PreCommit(const TId: TTransactionId; Phase: TMemDBPreCommitPhase; Opts:TOptimizeSet); override;
     procedure ToJournal(const Tid: TTransactionId; Stream: TStream);override;
     procedure ToScratch(const PseudoTid:TTransactionId; Stream: TStream);override;
@@ -417,7 +418,7 @@ type
 
     procedure Init(Parent: TMemDBTablePersistent; const Tid: TTransactionId);
 
-    function SizeHint: Int64;
+    function ChangedRowCount: Int64;
 
     procedure ToJournal(Stream: TStream);
     procedure ToScratch(Stream: TStream);
@@ -428,8 +429,8 @@ type
     procedure Commit;
     procedure Rollback;
 
-    procedure IndexCommit;
-    procedure IndexRollback;
+    procedure IndexCommit(Ctxt: TTXLocalContext);
+    procedure IndexRollback(Ctxt: TTXLocalContext);
 
     function ThrottleBuildCheckPartialIndexParallel(Ref1, Ref2: pointer): pointer;
     function ThrottleBuildCheckPartialInternalIndexParallel(Ref1, Ref2: pointer): pointer;
@@ -580,7 +581,7 @@ type
     constructor Create;
     destructor Destroy; override;
 
-    procedure SizeHint(const Tid: TTransactionId; var SizeHint: int64); override;
+    procedure SizeHint(const Tid: TTransactionId; var SizeHint: TDBSizeHint); override;
     procedure StartTransaction(const Tid: TTRansactionId); override;
     procedure Prepare(const Tid: TTransactionId; Opts:TOptimizeSet; FromScratch: boolean); override;
 
@@ -590,8 +591,8 @@ type
     procedure FromScratch(const PseudoTid: TTransactionId; Stream: TStream; Opts:TOptimizeSet); override;
 
     procedure PreCommit(const TId: TTransactionId; Phase: TMemDBPreCommitPhase; Opts:TOptimizeSet); override;
-    procedure Commit(const TId: TTransactionId; Phase: TMemDBCommitPhase; Opts:TOptimizeSet); override;
-    procedure Rollback(const TId: TTransactionId; Phase: TMemDBRollbackPhase; Opts:TOptimizeSet); override;
+    procedure Commit(const TId: TTransactionId; Phase: TMemDBCommitPhase; Opts:TOptimizeSet; Ctxt: TTXLocalContext); override;
+    procedure Rollback(const TId: TTransactionId; Phase: TMemDBRollbackPhase; Opts:TOptimizeSet; Ctxt: TTXLocalContext); override;
 
     function DataChangedForTid(const Tid:TTransactionId): boolean;
     function LayoutChangesRequiredForTid(const Tid: TTransactionId): boolean;
@@ -651,10 +652,11 @@ type
                              var EntityName: string);
     //Atomically get and assemble list of entities.
     function AssembleEntityList: TReffedList;
+    procedure ConsolidateAndFreeCaches(Ctxt: TTXLocalContext);
   public
     function EntitiesByName(const AB:TBufSelector; Name: string; PinReason: TPinReason): TMemDBEntity;
 
-    procedure SizeHint(const Tid: TTransactionId; var SizeHint: int64); virtual;
+    procedure SizeHint(const Tid: TTransactionId; var SizeHint: TDBSizeHint); virtual;
 
     function PrepareParallel(Ref1, Ref2: pointer):pointer;
     procedure Prepare(const Tid: TTransactionId; Opts:TOptimizeSet; FromScratch: boolean); virtual;
@@ -673,8 +675,8 @@ type
     function RollbackParallel(Ref1, Ref2: pointer): pointer;
 
     procedure PreCommit(const TId: TTransactionId; Phase: TMemDBPreCommitPhase;  Opts:TOptimizeSet); override;
-    procedure Commit(const TId: TTransactionId; Phase: TMemDBCommitPhase;  Opts:TOptimizeSet); override;
-    procedure Rollback(const TId: TTransactionId; Phase: TMemDBRollbackPhase;  Opts:TOptimizeSet); override;
+    procedure Commit(const TId: TTransactionId; Phase: TMemDBCommitPhase;  Opts:TOptimizeSet; Ctxt: TTXLocalContext); override;
+    procedure Rollback(const TId: TTransactionId; Phase: TMemDBRollbackPhase;  Opts:TOptimizeSet; Ctxt: TTXLocalContext); override;
 
     constructor Create;
     destructor Destroy; override;
@@ -1468,7 +1470,7 @@ begin
   FMetadata.PinCurrent(Tid, pinEvolve);
 end;
 
-procedure TMemDBEntity.SizeHint(const Tid: TTransactionId; var SizeHint: int64);
+procedure TMemDBEntity.SizeHint(const Tid: TTransactionId; var SizeHint: TDBSizeHint);
 begin
   //NOP.
 end;
@@ -1487,18 +1489,18 @@ begin
   //changed behind our back.
 end;
 
-procedure TMemDBEntity.Commit(const TId: TTransactionId; Phase:TMemDBCommitPhase; Opts:TOptimizeSet);
+procedure TMemDBEntity.Commit(const TId: TTransactionId; Phase:TMemDBCommitPhase; Opts:TOptimizeSet; Ctxt: TTXLocalContext);
 begin
   inherited;
   if Phase = ccpMetaIndex then
-    FMetadata.Commit(Tid, Phase, Opts);
+    FMetadata.Commit(Tid, Phase, Opts, Ctxt);
 end;
 
-procedure TMemDBEntity.Rollback(const TId: TTransactionId; Phase: TMemDBRollbackPhase; Opts:TOptimizeSet);
+procedure TMemDBEntity.Rollback(const TId: TTransactionId; Phase: TMemDBRollbackPhase; Opts:TOptimizeSet; Ctxt: TTXLocalContext);
 begin
   inherited;
   if Phase = rbpMetaRollback then
-    FMetadata.Rollback(Tid, Phase, Opts);
+    FMetadata.Rollback(Tid, Phase, Opts, Ctxt);
 end;
 
 procedure TMemDBEntity.Init(const Tid: TTransactionId; Parent: TObject; Name:string; DSName: boolean);
@@ -2136,7 +2138,7 @@ begin
   inherited;
 end;
 
-function TTidLocal.SizeHint: Int64;
+function TTidLocal.ChangedRowCount: Int64;
 begin
   result := FCPRows.Count;
 end;
@@ -2784,7 +2786,7 @@ begin
   finally
     for j := 0 to Pred(IPinListTmp.Count) do
       if IPinListTmp[j] <> result then
-        Row.ReleaseIndexPinOutsideLock(IPinListTmp[j]);
+        Row.ReleaseIndexPinOutsideLock(IPinListTmp[j], nil); //Cannot cache hint if its not ours.
   end;
 end;
 
@@ -2842,6 +2844,13 @@ begin
 
   ListTmp := nil;
   try
+    //Worst case is 3/2 number of changed nodes: An entire tree,
+    //plus rewrites of every node above top level, plus small cache size
+    //for temps.
+    //If mem alloc fails, no problem, it'll just go at snail pace.
+    //TODO - tune this.
+    Index.PushLargeCache(((3* FCPRows.Count) div 2) + SMALL_NODE_PIN_CACHE_SIZE);
+
     //TidLocal row set will not change under commit lock.
     IRec := FCPRows.GetAnItem;
     while Assigned(IRec) do
@@ -2867,7 +2876,7 @@ begin
             if not Ret then
               raise EMemDBInternalException.Create(S_ERROR_MODIFYING_INDEX_REMOVE);
           finally
-            Row.ReleaseIndexPinOutsideLock(IPin);
+            Row.ReleaseIndexPinOutsideLock(IPin, Index.NodeCache);
           end;
         end
         else if Added or Null then
@@ -2878,7 +2887,7 @@ begin
             if Assigned(IPin) then
               raise EMemDBInternalException.Create(S_ERROR_UNEXPECTED_PIN_FOR_INDEX_REMOVE);
           finally
-            Row.ReleaseIndexPinOutsideLock(IPin);
+            Row.ReleaseIndexPinOutsideLock(IPin, Index.NodeCache);
           end;
   {$ENDIF}
         end;
@@ -2991,7 +3000,7 @@ begin
           if Assigned(IPin) then
           begin
             Assert(Assigned(Row));
-            Row.ReleaseIndexPinOutsideLock(IPin);
+            Row.ReleaseIndexPinOutsideLock(IPin, Index.NodeCache);
           end;
         end;
 
@@ -3040,6 +3049,13 @@ begin
   //TidLocal row set will not change under commit lock.
   ListTmp := nil;
   try
+    //Worst case is 3/2 number of changed nodes: An entire tree,
+    //plus rewrites of every node above top level, plus small cache size
+    //for temps.
+    //If mem alloc fails, no problem, it'll just go at snail pace.
+    //TODO - tune this.
+    Index.PushLargeCache(((3* FCPRows.Count) div 2) + SMALL_NODE_PIN_CACHE_SIZE);
+
     IRec := FCPRows.GetAnItem;
     while Assigned(IRec) do
     begin
@@ -3064,7 +3080,7 @@ begin
             if not Ret then
               raise EMemDBInternalException.Create(S_ERROR_MODIFYING_INTERNAL_INDEX_REMOVE);
           finally
-            Row.ReleaseIndexPinOutsideLock(IPin);
+            Row.ReleaseIndexPinOutsideLock(IPin, Index.NodeCache);
           end;
         end
         else if Added or Null then
@@ -3075,7 +3091,7 @@ begin
             if Assigned(IPin) then
               raise EMemDBInternalException.Create(S_ERROR_UNEXPECTED_PIN_FOR_INTERNAL_INDEX_REMOVE);
           finally
-            Row.ReleaseIndexPinOutsideLock(IPin);
+            Row.ReleaseIndexPinOutsideLock(IPin, Index.NodeCache);
           end;
   {$ENDIF}
         end;
@@ -3164,7 +3180,7 @@ begin
     ExecParallel(Handlers, Refs1, refs2, Excepts, Rets, @MemDBXlateExceptions);
 end;
 
-procedure TTidLocal.IndexCommit;
+procedure TTidLocal.IndexCommit(Ctxt: TTXLocalContext);
 var
   i: integer;
   AddOrRebuild: boolean;
@@ -3237,8 +3253,10 @@ begin
                 '(' + IntToStr(NativeUint(Index)) + ')');
 {$ENDIF}
 
-        Index.CommitNextToRoot;
+        Index.CommitNextToRoot(true);
+        (Ctxt as TXEntityLocalContext).AddCache(Index.PopLargeCache);
       end;
+
     end;
     //And pack master indexes.
     FParentTable.FMasterIndexes.Pack;
@@ -3291,11 +3309,12 @@ begin
                 '*** Commit evolved IntIdx [' +IntToStr(-1) + '] ' +
                 '(' + IntToStr(NativeUint(FParentTable.FMasterInternalIndex)) + ')');
 {$ENDIF}
-        FParentTable.FMasterInternalIndex.CommitNextToRoot;
+        FParentTable.FMasterInternalIndex.CommitNextToRoot(true);
+        (Ctxt as TXEntityLocalContext).AddCache(FParentTable.FMasterInternalIndex.PopLargeCache);
       end;
     end;
   end
-  else
+  else //No indexing change required.
   begin
     for i := 0 to Pred(FParentTable.FMasterIndexes.Count) do
     begin
@@ -3307,7 +3326,8 @@ begin
                 '(' + IntToStr(NativeUint(Index)) + ')');
 {$ENDIF}
 
-      Index.CommitNextToRoot;
+      Index.CommitNextToRoot(true);
+      (Ctxt as TXEntityLocalContext).AddCache(Index.PopLargeCache);
     end;
     //Generally expect this to be assigned, but we'll be careful and
     //check all the same. Post-delete commit gets this far?
@@ -3320,12 +3340,13 @@ begin
                 ' Commit evolved IntIdx [' +IntToStr(-1) + '] ' +
                 '(' + IntToStr(NativeUint(FParentTable.FMasterInternalIndex)) + ')');
 {$ENDIF}
-      FParentTable.FMasterInternalIndex.CommitNextToRoot;
+      FParentTable.FMasterInternalIndex.CommitNextToRoot(true);
+      (Ctxt as TXEntityLocalContext).AddCache(FParentTable.FMasterInternalIndex.PopLargeCache);
     end;
   end;
 end;
 
-procedure TTidLocal.IndexRollback;
+procedure TTidLocal.IndexRollback(Ctxt: TTXLocalContext);
 var
   i: integer;
   Index: TMemDBIndex;
@@ -3341,7 +3362,8 @@ begin
             '(' + IntToStr(NativeUint(Index)) + ')');
 {$ENDIF}
 
-    Index.DiscardNext;
+    Index.DiscardNext(true);
+    (Ctxt as TXEntityLocalContext).AddCache(Index.PopLargeCache);
   end;
   //Master internal index not always assigned in rollback case (new index build).
   if Assigned(FParentTable.FMasterInternalIndex) then
@@ -3351,7 +3373,8 @@ begin
             ' Rollback IntIdx [' +IntToStr(-1) + '] ' +
             '(' + IntToStr(NativeUint(FParentTable.FMasterInternalIndex)) + ')');
 {$ENDIF}
-    FParentTable.FMasterInternalIndex.DiscardNext;
+    FParentTable.FMasterInternalIndex.DiscardNext(true);
+    (Ctxt as TXEntityLocalContext).AddCache(FParentTable.FMasterInternalIndex.PopLargeCache);
   end;
   //Else new build master index not swizzled on yet, TidLocal destroy will clean it up.
 end;
@@ -3423,7 +3446,7 @@ begin
   begin
     Row := IRec.Item as TMemDBRow;
     Assert(Row <> LastRow); //Just check the commit is removing things as it should.
-    Row.Commit(FTid, ccpData, []);
+    Row.Commit(FTid, ccpData, [], nil);
     LastRow := Row;
     IRec := FCPRows.GetAnItem;
   end;
@@ -3444,7 +3467,7 @@ begin
   begin
     Row := IRec.Item as TMemDBRow;
     Assert(Row <> LastRow); //Just check the rollback is removing things as it should.
-    Row.Rollback(FTid, rbpDelayedRollback, []);
+    Row.Rollback(FTid, rbpDelayedRollback, [], nil);
     LastRow := Row;
     IRec := FCPRows.GetAnItem;
   end;
@@ -3577,7 +3600,8 @@ begin
               //Can be deleted by other API object in same transaction ...
 
             INode := IPin.INode;
-            Cursor.Row.ReleaseIndexPinOutsideLock(IPin);
+            Cursor.Row.ReleaseIndexPinOutsideLock(IPin, nil); //Not caching user ops yet.
+
             //We know the tree we're looking for is not ephemeral form our point of view
             //so can release IPin here.
           end;
@@ -4434,13 +4458,40 @@ begin
   end;
 end;
 
-procedure TMemDBTablePersistent.SizeHint(const Tid: TTransactionId; var SizeHint: int64);
+procedure TMemDBTablePersistent.SizeHint(const Tid: TTransactionId; var SizeHint: TDBSizeHint);
 var
   TidLocal: TTidLocal;
+  TotalRowCount: Int64;
+  i: integer;
 begin
   TidLocal := GetTidLocal(Tid);
   if Assigned(TidLocal) then
-    Inc(SizeHint, TidLocal.SizeHint);
+  begin
+    if SizeHint.ShouldUpdateLayout then
+      TidLocal.UpdateLayout(pinEvolve); //May not be possible to in some rollback cases.
+
+    if Assigned(TidLocal.FIndexHelper) then
+    begin
+      //I can't remember under what conditions/commit/rollback this is assigned.
+      //An estimate is fine for now.
+      Inc(SizeHint.TotalIndexes, TidLocal.FIndexHelper.Count);
+    end;
+
+    Inc(SizeHint.ChangedRows, TidLocal.ChangedRowCount);
+    //OK, now calculate the number of possibly re-indexed rows.
+    FMasterRowLock.Acquire;
+    try
+      TotalRowCount := FMasterRowList.Count;
+    finally
+      FMasterRowLock.Release;
+    end;
+    for i := 0 to Pred(Length(TidLocal.FIndexChangesets)) do
+    begin
+      if TidLocal.FIndexChangesets[i] * [ictAdded, ictChangedFieldNumber] <> [] then
+        Inc(SizeHint.IndexBuildRows, TotalRowCount);
+    end;
+    Inc(SizeHint.TotalRows, TotalRowCount);
+  end;
 end;
 
 procedure TMemDBTablePersistent.PreCommit(const TId: TTransactionId; Phase: TMemDBPreCommitPhase; Opts:TOptimizeSet);
@@ -4472,7 +4523,7 @@ begin
 end;
 
 
-procedure TMemDBTablePersistent.Commit(const TId: TTransactionId; Phase: TMemDBCommitPhase; Opts:TOptimizeSet);
+procedure TMemDBTablePersistent.Commit(const TId: TTransactionId; Phase: TMemDBCommitPhase; Opts:TOptimizeSet; Ctxt: TTXLocalContext);
 var
   TidLocal: TTidLocal;
 begin
@@ -4487,7 +4538,7 @@ begin
   case Phase of
     ccpData: TidLocal.Commit;
     ccpMetaIndex: begin
-      TidLocal.IndexCommit;
+      TidLocal.IndexCommit(CTxt);
       inherited;
       FindRmRowProhibitLocks(Tid);
     end;
@@ -4497,7 +4548,7 @@ begin
   end;
 end;
 
-procedure TMemDBTablePersistent.Rollback(const TId: TTransactionId; Phase: TMemDBRollbackPhase; Opts:TOptimizeSet);
+procedure TMemDBTablePersistent.Rollback(const TId: TTransactionId; Phase: TMemDBRollbackPhase; Opts:TOptimizeSet; Ctxt: TTXLocalContext);
 var
   TidLocal: TTidLocal;
 begin
@@ -4512,7 +4563,7 @@ begin
   begin
     //Some very pathalogical cases involve rollback for nonexistent Tid.
     case Phase of
-      rbpIndexRollback: TidLocal.IndexRollback;
+      rbpIndexRollback: TidLocal.IndexRollback(Ctxt);
       rbpMetaRollback: inherited;
       rbpDelayedRollback: begin
         TidLocal.Rollback;
@@ -4763,6 +4814,19 @@ begin
   ExpectTag(Stream, mstFkStart);
   FMetadata.FromScratch(PseudoTid, Stream, Opts);
   ExpectTag(Stream, mstFkEnd);
+end;
+
+procedure TMemDBForeignKeyPersistent.SizeHint(const Tid: TTransactionId; var SizeHint: TDBSizeHint);
+var
+  CP, NP: TMemDBStreamable;
+  Added, Changed, Deleted, Null: boolean;
+begin
+  CP := FMetadata.PinCurrent(Tid, pinFinalCheck);
+  NP := FMetadata.GetNext(Tid);
+  ChangeFlagsFromPinned(CP, NP, Added, Changed, Deleted, Null);
+
+  if Added then
+    SizeHint.FKAdd := true;
 end;
 
 procedure TMemDBForeignKeyPersistent.PreCommit(const Tid: TTransactionId; Phase: TMemDBPreCommitPhase; Opts:TOptimizeSet);
@@ -5658,6 +5722,7 @@ begin
       raise EMemDBInternalException.Create(S_FKEYS_INTERNAL_19);
   end;
 
+  //TODO - FKLists parallel.
   try
     //N.B. Indexed store gives us a "duplicate key" error code, which we should use.
     CreateReferringAddedList(Meta);
@@ -6050,7 +6115,7 @@ begin
   except
     while List.Count > 0 do
     begin
-      ReleaseIndexPinOutsideLock(PMemDbIndexPin(List.Items[Pred(List.Count)]));
+      ReleaseIndexPinOutsideLock(PMemDbIndexPin(List.Items[Pred(List.Count)]), nil);
       List.Delete(Pred(List.Count));
     end;
     raise;
@@ -6082,7 +6147,7 @@ begin
             raise EMemDBInternalException.Create(S_LOCAL_INDEX_DELETION_BAD_2);
       finally
         if Assigned(Pin) then
-          ReleaseIndexPinOutsideLock(Pin);
+          ReleaseIndexPinOutsideLock(Pin, nil);
       end;
     end;
   finally
@@ -6119,7 +6184,7 @@ begin
           Assert(Pin.INode.OriginalIndex = Index);
           raise EMemDBInternalException.Create(S_LOCAL_INDEX_INSERTION_DUPLICATE);
         finally
-          ReleaseIndexPinOutsideLock(Pin);
+          ReleaseIndexPinOutsideLock(Pin, nil);
         end;
       end;
 {$ENDIF}
@@ -6993,6 +7058,7 @@ type
     Tid: TTransactionId;
     Phase: TMemDBCommitPhase;
     Opts: TOptimizeSet;
+    Ctxt: TTXLocalContext;
   end;
   PPOCommitContext = ^TPOCommitContext;
 
@@ -7006,14 +7072,14 @@ begin
 
   Entity.FParentDB.FEntityThrottle.Acquire;
   try
-    Entity.Commit(PPOContext.Tid, PPOContext.Phase, PPOContext.Opts);
+    Entity.Commit(PPOContext.Tid, PPOContext.Phase, PPOContext.Opts, PPOContext.Ctxt);
   finally
     Entity.FParentDB.FEntityThrottle.Release;
   end;
   result := nil;
 end;
 
-procedure TMemDBDatabasePersistent.Commit(const TId: TTransactionId; Phase: TMemDBCommitPhase; Opts:TOptimizeSet);
+procedure TMemDBDatabasePersistent.Commit(const TId: TTransactionId; Phase: TMemDBCommitPhase; Opts:TOptimizeSet; Ctxt: TTXLocalContext);
 var
   EntityList: TReffedList;
   Proxy: TMemDBEntityProxy;
@@ -7036,6 +7102,7 @@ begin
     TPOComm.Tid := Tid;
     TPOComm.Phase := Phase;
     TPOComm.Opts := Opts;
+    TPOComm.Ctxt := Ctxt;
   end;
 
   EntityList := AssembleEntityList;
@@ -7050,13 +7117,14 @@ begin
           Handlers, Refs1, Refs2, Excepts, Rets, PCount);
       end
       else
-        Entity.Commit(Tid, Phase, Opts);
+        Entity.Commit(Tid, Phase, Opts, Ctxt);
     end;
     if OptApplies(optEntitiesParallel, Opts) and (PCount > 0) then
       ExecParallel(Handlers, Refs1, Refs2, Excepts, Rets, @MemDBXlateExceptions);
   finally
     EntityList.Release;
   end;
+  ConsolidateAndFreeCaches(Ctxt);
 end;
 
 type
@@ -7064,6 +7132,7 @@ type
     Tid: TTransactionId;
     Phase: TMemDBRollbackPhase;
     Opts: TOptimizeSet;
+    Ctxt: TTXLocalContext;
   end;
   PPORollbackContext = ^TPORollbackContext;
 
@@ -7077,14 +7146,14 @@ begin
 
   Entity.FParentDB.FEntityThrottle.Acquire;
   try
-    Entity.Rollback(PPORoll.Tid, PPORoll.Phase, PPORoll.Opts);
+    Entity.Rollback(PPORoll.Tid, PPORoll.Phase, PPORoll.Opts, PPORoll.Ctxt);
   finally
     Entity.FParentDB.FEntityThrottle.Release;
   end;
   result := nil;
 end;
 
-procedure TMemDBDatabasePersistent.Rollback(const TId: TTransactionId; Phase: TMemDBRollbackPhase; Opts:TOptimizeSet);
+procedure TMemDBDatabasePersistent.Rollback(const TId: TTransactionId; Phase: TMemDBRollbackPhase; Opts:TOptimizeSet; Ctxt: TTXLocalContext);
 var
   EntityList: TReffedList;
   Proxy: TMemDBEntityProxy;
@@ -7107,6 +7176,7 @@ begin
     TPORoll.Tid := Tid;
     TPORoll.Phase := Phase;
     TPORoll.Opts := Opts;
+    TPORoll.Ctxt := Ctxt;
   end;
 
   //TODO - Entity list allocation during rollback of out-of-memory cases.
@@ -7122,23 +7192,51 @@ begin
           Handlers, refs1, Refs2, Excepts, Rets, PCount);
       end
       else
-        Entity.Rollback(Tid, Phase, Opts);
+        Entity.Rollback(Tid, Phase, Opts, Ctxt);
     end;
     if OptApplies(optEntitiesParallel, Opts) and (PCount > 0) then
       ExecParallel(Handlers, Refs1, Refs2, Excepts, Rets, @MemDBXlateExceptions);
   finally
     EntityList.Release;
   end;
+  ConsolidateAndFreeCaches(Ctxt);
 end;
 
-procedure TMemDBDatabasePersistent.SizeHint(const Tid: TTransactionID; var SizeHint: Int64);
+procedure TMemDBDatabasePersistent.ConsolidateAndFreeCaches(Ctxt: TTXLocalContext);
+var
+  MCache: TMemDbNodeCache;
+  CETxt: TXEntityLocalContext;
+  i, TSize: integer;
+begin
+  //This does not *have* to work, things will just run faster when it does.
+  //Put all the caches together, put into one big sorted list,
+  //And then free the whole lot sequentially.
+  CETxt := Ctxt as TXEntityLocalContext;
+  MCache := nil;
+  TSize := 0;
+  try
+    for i := 0 to Pred(CETxt.FCacheList.Count) do
+      Inc(TSize, TMemDBNodeCache(CETxt.FCacheList[i]).Count);
+    MCache := TMemDBNodeCache.Create;
+    MCache.Capacity := TSize;
+    for i := 0 to Pred(CETxt.FCacheList.Count) do
+      MCache.TakeNodesFrom(TMemDBNodeCache(CETxt.FCacheList[i]));
+    for i := 0 to Pred(CETxt.FCacheList.Count) do
+      TMemDBNodeCache(CETxt.FCacheList[i]).Free;
+    CETxt.FCacheList.Clear;
+  except
+    on EOutOfMemory do
+  end;
+  MCache.Free;
+end;
+
+procedure TMemDBDatabasePersistent.SizeHint(const Tid: TTransactionID; var SizeHint: TDBSizeHint);
 var
   EntityList: TReffedList;
   Proxy: TMemDBEntityProxy;
   Entity: TMemDbEntity;
   i: integer;
 begin
-  SizeHint := 0;
   EntityList := AssembleEntityList;
   try
     for i := 0 to Pred(EntityList.Count) do
@@ -7259,10 +7357,12 @@ var
   Entity: TMemDbEntity;
   NullStream: TNullStream;
   FKs, Del: boolean;
+  Ctxt: TXEntityLocalContext;
 {$ENDIF}
 begin
 {$IFDEF CHECK_TEARDOWN_REFS}
   NullStream := TNullStream.Create;
+  Ctxt := TXEntityLocalContext.Create;
   try
     for FKs := True downto False do
     begin
@@ -7290,12 +7390,13 @@ begin
       ToJournal(PseudoTid, NullStream);
       PreCommit(PseudoTid, pcpFKeys, CleardownOptSet);
       PreCommit(PseudoTid, pcpTables, CleardownOptSet);
-      Commit(PseudoTid, ccpData, CleardownOptSet);
-      Commit(PseudoTid, ccpMetaIndex, []);
-      Commit(PseudoTid, ccpCleardown, CleardownOptSet);
+      Commit(PseudoTid, ccpData, CleardownOptSet, Ctxt);
+      Commit(PseudoTid, ccpMetaIndex, [], Ctxt);
+      Commit(PseudoTid, ccpCleardown, CleardownOptSet, Ctxt);
     end;
   finally
     NullStream.Free;
+    Ctxt.Free;
   end;
 {$ELSE}
   //TODO - Harden this to handle out of memory conditions.

--- a/Common/MemDB2/MemDB2Indexing.pas
+++ b/Common/MemDB2/MemDB2Indexing.pas
@@ -35,9 +35,6 @@ uses
 {$ENDIF}
   MemDB2Misc, MemDB2Streamable, CowTree, IndexedStore, Reffed, Classes;
 
-const
-  NODE_CACHE_SIZE = 64; //Longest possible path + rebalances
-
 type
   TMemDbIndexLeafGeneric = class;
 
@@ -45,12 +42,19 @@ type
   protected
     FPtrs: TList;
     FPinCache: TObject;
+  protected
+    function GetCount: integer;
+    function GetCapacity: integer;
+    procedure SetCapacity(Capacity: integer);
   public
     constructor Create;
     destructor Destroy; override;
     function GetFromCache: TReffed; override;
     function PutToCache(Reffed: TReffed): boolean; override;
+    procedure TakeNodesFrom(Cache: TMemDbNodeCache);
     property PinCache: TObject read FPinCache;
+    property Capacity: integer read GetCapacity write SetCapacity;
+    property Count: integer read GetCount;
   end;
 
   { Quick reminder. Indexes are *immutable* once created,
@@ -61,7 +65,10 @@ type
     FRoot: TMemDBIndexLeafGeneric;
     FNext: TMemDBIndexLeafGeneric;
   protected
+    FStandbyCache: TMemDBNodeCache;
+
     function SelToRoot(Sel: TAbSelType): TMemDBIndexLeafGeneric;
+    function GetNodeCache: TMemDBNodeCache;
   public
     constructor Create; virtual;
     destructor Destroy; override;
@@ -83,9 +90,14 @@ type
     function Add(Sel: TAbSelType; var New: TMemDBIndexLeafGeneric): boolean;
     function Remove(Sel: TAbSelType; Old: TMemDBIndexLeafGeneric): boolean;
 
-    procedure RootToNext;
-    procedure CommitNextToRoot;
-    procedure DiscardNext;
+    procedure RootToNext(UseCache: boolean = false);
+    procedure CommitNextToRoot(UseCache: boolean = false);
+    procedure DiscardNext(UseCache: boolean = false);
+
+    procedure PushLargeCache(Capacity: integer);
+    function PopLargeCache: TMemDbNodeCache;
+
+    property NodeCache: TMemDbNodeCache read GetNodeCache;
 
     property ParentIndex: TMemDbIndexGeneric read FParentIndex;
   end;
@@ -152,7 +164,6 @@ type
     procedure SetRow(NewRow: TObject);
 {$ENDIF}
   protected
-    class function ComparePointers(Own, Other: Pointer): integer;
     function DupNoInit(SrcTree: TCowTree): TCowTreeItem; override;
   public
     destructor Destroy; override;
@@ -385,13 +396,15 @@ constructor TMemDBNodeCache.Create;
 begin
   inherited;
   FPtrs := TList.Create;
-  FPinCache :=  TMemDBPinCache.Create;
+  FPtrs.Capacity := SMALL_NODE_PIN_CACHE_SIZE;
+  FPinCache :=  TMemDBIPinCache.Create;
 end;
 
 destructor TMemDBNodeCache.Destroy;
 var
   i: integer;
 begin
+  FPtrs.Sort(ComparePointers);
   for i := 0 to Pred(FPtrs.Count) do
     TReffed(FPtrs[i]).Release; //Refcounts 1 for cached objects.
   FPtrs.Free;
@@ -421,7 +434,7 @@ begin
   if Assigned(Reffed) then
   begin
     Count := FPtrs.Count;
-    if Count < NODE_CACHE_SIZE then
+    if Count < FPtrs.Capacity then
     begin
       FPtrs.Add(Reffed); //Add before reset so size calc is OK ...
       Reffed.Reset(self);
@@ -432,6 +445,33 @@ begin
   end
   else
     result := true;
+end;
+
+procedure TMemDBNodeCache.TakeNodesFrom(Cache: TMemDbNodeCache);
+var
+  i: integer;
+begin
+  for i := 0 to Pred(Cache.FPtrs.Count) do
+    FPtrs.Add(Cache.FPtrs[i]);
+  Cache.FPtrs.Clear;
+  (FPinCache as TMemDBIPinCache).TakeNodesFrom(Cache.FPinCache as TMemDBIPinCache);
+end;
+
+function TMemDBNodeCache.GetCount: integer;
+begin
+  result := FPtrs.Count;
+end;
+
+function TMemDBNodeCache.GetCapacity: integer;
+begin
+  result := FPtrs.Capacity;
+end;
+
+procedure TMemDBNodeCache.SetCapacity(Capacity: integer);
+begin
+  Assert(Capacity >= FPtrs.Count);
+  FPtrs.Capacity := Capacity;
+  (FPinCache as TMemDBIPinCache).Capacity := Capacity;
 end;
 
 { TMemDBIndexGeneric }
@@ -466,24 +506,70 @@ begin
   end
 end;
 
-procedure TMemDbIndexGeneric.RootToNext;
+procedure TMemDbIndexGeneric.RootToNext(UseCache: boolean = false);
 begin
-  FNext.Release;
+  if UseCache then
+    FNext.ReleaseToCache(FCache)
+  else
+    FNext.Release;
   FNext := FRoot.AddRef as TMemDBIndexLeaf;
 end;
 
-procedure TMemDbIndexGeneric.CommitNextToRoot;
+procedure TMemDbIndexGeneric.CommitNextToRoot(UseCache: boolean = false);
 begin
-  FRoot.Release;
+  if UseCache then
+    FRoot.ReleaseToCache(FCache)
+  else
+    FRoot.Release;
   FRoot := FNext;
   FNext := nil;
 end;
 
-procedure TMemDbIndexGeneric.DiscardNext;
+procedure TMemDbIndexGeneric.DiscardNext(UseCache: boolean = false);
 begin
-  FNext.Release;
+  if UseCache then
+    FNext.ReleaseToCache(FCache)
+  else
+    FNext.Release;
   FNext := nil;
 end;
+
+procedure TMemDbIndexGeneric.PushLargeCache(Capacity: integer);
+var
+  Tmp: TMemDBNodeCache;
+begin
+  if not Assigned(FStandbyCache) then
+  begin
+    Tmp := nil;
+    try
+      Tmp := TMemDbNodeCache.Create;
+      Tmp.Capacity := Capacity;
+      FStandbyCache := FCache as TMemDBNodeCache;
+      FCache := tmp;
+    except
+      on EOutOfMemory do
+        Tmp.Free;
+    end;
+  end;
+end;
+
+function TMemDbIndexGeneric.PopLargeCache: TMemDbNodeCache;
+begin
+  if Assigned(FStandbyCache) then
+  begin
+    result := FCache as TMemDBNodeCache;
+    FCache := FStandbyCache;
+    FStandbyCache := nil;
+  end
+  else
+    result := nil;
+end;
+
+function TMemDBIndexGeneric.GetNodeCache: TMemDBNodeCache;
+begin
+  result := FCache as TMemDbNodeCache;
+end;
+
 
 function TMemDbIndexGeneric.SelToRoot(Sel: TAbSelType): TMemDBIndexLeafGeneric;
 begin
@@ -817,16 +903,16 @@ end;
 procedure TMemDBIndexLeafGeneric.Reset(Cache: TReffedCache);
 var
   NCache: TMemDBNodeCache;
-  PCache: TMemDBPinCache;
+  PCache: TMemDBIPinCache;
 begin
   Assert(Assigned(self.FPin) = Assigned(self.FRow));
   Assert(Assigned(Cache));
 {$IFOPT C+}
   NCache := Cache as TMemDbNodeCache;
-  PCache := NCache.PinCache as TMemDBPinCache;
+  PCache := NCache.PinCache as TMemDBIPinCache;
 {$ELSE}
   NCache := TMemDBNodeCache(Cache);
-  PCache := TMemDbPinCache(NCache.PinCache);
+  PCache := TMemDBIPinCache(NCache.PinCache);
 {$ENDIF}
   if Assigned(FPin) then
     (FRow as TMemDBRow).UnpinFromIndex(self, PCache);
@@ -875,7 +961,7 @@ var
 {$ENDIF}
   IndexCheck: TMemDBIndexGeneric;
   NCache: TMemDBNodeCache;
-  PCache: TMemDBPinCache;
+  PCache: TMemDBIPinCache;
 begin
   Assert(Assigned(Source) and (Source.ClassType = Self.ClassType));
   SL := TMemDBIndexLeafGeneric(Source);
@@ -900,14 +986,14 @@ begin
   IndexCheck := SrcTree as TMemDBIndexGeneric;
   NCache := IndexCheck.FCache as TMemDbNodeCache;
   if Assigned(NCache) then
-    PCache := NCache.PinCache as TMemDBPinCache
+    PCache := NCache.PinCache as TMemDBIPinCache
   else
     PCache := nil;
 {$ELSE}
   IndexCheck := TMemDbIndexGeneric(SrcTree);
   NCache := TMemDBNodeCache(IndexCheck.FCache);
   if Assigned(NCache) then
-    PCache := TMemDBPinCache(NCache.PinCache)
+    PCache := TMemDBIPinCache(NCache.PinCache)
   else
     PCache := nil;
 {$ENDIF}
@@ -916,39 +1002,6 @@ begin
   //otherwise very bad things happen...
   Assert(PMemDBIndexPin(self.FPin).PinnedItem = PMemDBIndexPin(SL.FPin).PinnedItem);
 end;
-
-{$HINTS OFF}
-class function TMemDbIndexLeafGeneric.ComparePointers(Own, Other: Pointer): integer;
-var
-  OwnInt, OtherInt: Cardinal;
-  Own64, Other64: UInt64;
-begin
-  if sizeof(Pointer) = sizeof(Cardinal) then
-  begin
-    OwnInt := Cardinal(Own);
-    OtherInt := Cardinal(Other);
-    if OtherInt > OwnInt then
-      result := 1
-    else if OtherInt < OwnInt then
-      result := -1
-    else
-      result := 0;
-  end
-  else if sizeof(Pointer) = sizeof(UInt64) then
-  begin
-    Own64 := UInt64(Own);
-    Other64 := UInt64(Other);
-    if Other64 > Own64 then
-      result := 1
-    else if Other64 < Own64 then
-      result := -1
-    else
-      result := 0;
-  end
-  else
-    Assert(false);
-end;
-{$HINTS ON}
 
 { TMemDbIndexLeaf }
 

--- a/Common/MemDB2/MemDB2Misc.pas
+++ b/Common/MemDB2/MemDB2Misc.pas
@@ -204,6 +204,7 @@ type
                   EnabledReplayNext: boolean;
                   EnabledUserOps: boolean; );
     optTxionSize: ( EnabledRowChangeCount: integer;
+                    EnabledFKRowsTotal: integer;
                     EnabledTxionBufSize: Int64;
                   );
   end;
@@ -221,6 +222,8 @@ const
   TWO_FIFTY_SIX_K = 256 * 1024;
   ONE_MEG = 1024*1024;
   FILE_CACHE_SIZE = ONE_MEG;
+
+  SMALL_NODE_PIN_CACHE_SIZE = 64; //Longest possible path + rebalances
 
   S_API_NOT_IMPLEMENTED = 'API not yet implemented.';
 
@@ -248,18 +251,22 @@ var
 
 procedure AppendTrailingDirSlash(var Path: string);
 
-{$IFOPT C+}
 function CompareGuids(const OtherGuid, OwnGuid: TGUID): integer;
-{$ELSE}
-function CompareGuids(const OtherGuid, OwnGuid: TGUID): integer; inline;
-{$ENDIF}
 
 //Optimization helper functions.
+type
+  TDBSizeHint = record
+    ChangedRows, IndexBuildRows, TotalRows: Int64;
+    TotalIndexes: integer;
+    FKAdd: boolean;
+    ShouldUpdateLayout: boolean;
+  end;
+
 function OptApplies(Opt: TOptimization; Opts: TOptimizeSet): boolean;
 
 function MakeOptimizationSet(const Policies: TOptimizePolicies;
                              InitFirstTrans, InitNextTrans, UserOp: boolean;
-                             RowCountEstimate: integer;
+                             DBSizeHint: TDBSizeHint;
                              TxionSizeEstimate: int64): TOptimizeSet;
 
 function CleardownOptSet: TOptimizeSet;
@@ -297,7 +304,7 @@ end;
 
 function MakeOptimizationSet(const Policies: TOptimizePolicies;
                              InitFirstTrans, InitNextTrans, UserOp: boolean;
-                             RowCountEstimate: integer;
+                             DBSizeHint: TDBSizeHint;
                              TxionSizeEstimate: int64): TOptimizeSet;
 var
   Opt: TOptimization;
@@ -313,8 +320,12 @@ begin
     optContext: DoOpt := (Policy.EnabledReplayFirst and InitFirstTrans) or
                          (Policy.EnabledReplayNext and InitNextTrans) or
                          (Policy.EnabledUserOps and UserOp);
-    optTxionSize: DoOpt := (RowCountEstimate > Policy.EnabledRowChangeCount) or
-                           (TxionSizeEstimate > Policy.EnabledTxionBufSize);
+    //TODO - optTxionSize can overestimate Txion size based on file size,
+    //and create threads for a bunch of tiny transactions.
+    optTxionSize: DoOpt := (DBSizeHint.ChangedRows + DBSizeHint.IndexBuildRows
+                              > Policy.EnabledRowChangeCount) or
+                           (TxionSizeEstimate > Policy.EnabledTxionBufSize) or
+                           (DBSizeHint.FKAdd and (DBSizeHint.TotalRows > Policy.EnabledFKRowsTotal));
    else
      Assert(false);
      DoOpt := false;
@@ -354,6 +365,7 @@ begin
     PolicyType := optTxionSize;
     EnabledRowChangeCount := THIRTY_TWO_K;
     EnabledTxionBufSize := TWO_FIFTY_SIX_K;
+    EnabledFKRowsTotal := TWO_FIFTY_SIX_K;
   end;
   with result[TOptimization.optIndexBuildParallel] do
   begin
@@ -365,6 +377,7 @@ begin
     PolicyType := optTxionSize;
     EnabledRowChangeCount := THIRTY_TWO_K;
     EnabledTxionBufSize := TWO_FIFTY_SIX_K;
+    EnabledFKRowsTotal := TWO_FIFTY_SIX_K;
   end;
 end;
 

--- a/Common/MemDB2/Test/MemDB2TestForm.pas
+++ b/Common/MemDB2/Test/MemDB2TestForm.pas
@@ -4471,34 +4471,6 @@ var
     end;
   end;
 
-  procedure BlocTableDelete;
-  begin
-    Trans := FSession.StartTransaction(WMode, amLazyWrite, Iso);
-    try
-      DBAPI := Trans.GetAPI;
-      try
-        DBAPI.DeleteTableOrKey('ExhaustMemTbl');
-      finally
-        DBAPI.Free;
-      end;
-      Trans.CommitAndFree;
-      LogtimeIncr('Exhaust memory bloc delete: amazingly, worked OK!!');
-    except
-      on E: EOutOfMemory do
-      begin
-        Trans.RollbackAndFree;
-        LogtimeIncr('Exhaust memory bloc delete: Expected memory exhaustion, OK.');
-        exit;
-      end;
-      on E: Exception do
-      begin
-        Trans.RollbackAndFree;
-        LogtimeIncr('Exhaust memory bloc delete unexpected failed: ' + E.Message);
-        raise;
-      end;
-    end;
-  end;
-
   procedure CarefulRowDelete;
   var
     BlocSize, BlocLeft: integer;
@@ -4532,7 +4504,7 @@ var
         on E: Exception do
         begin
           Trans.RollbackAndFree;
-          LogtimeIncr('Exhaust memory bloc delete unexpected failed: ' + E.Message);
+          LogtimeIncr('Exhaust memory careful row delete unexpected failed: ' + E.Message);
           raise;
         end;
       end;
@@ -4557,12 +4529,8 @@ begin
   //Now try to delete all the rows individually in the table (expect failure).
   BigRowDelete;
 
-  //Now try to delete the table en-bloc, (not sure if this will work).
-  BlocTableDelete;
-
   //Now slowly back the table out a few rows at a time.
   CarefulRowDelete;
-
 end;
 
 procedure TForm1.ResetClick(Sender: TObject);


### PR DESCRIPTION
MemDB2: Just a few notes.
MemDB2: Cleardown caches work well. Internal commit/rollback coming up to speed.
MemDB2: Added large index cleardown caches. Appears not to break anything ...
MemDB2: Improve FK SizeHints.
MemDB2: Improve size hints, index builds now faster.