### PR TITLE
MemDB2: Finished internal optimizations. Moving on to client ops.

### DIFF
--- a/Common/LockAbstractions/StripedLock.pas
+++ b/Common/LockAbstractions/StripedLock.pas
@@ -55,7 +55,7 @@ uses
 
 const
   LOCK_ARRAY_SIZE = Succ(High(Word));
-  A_LONGER_SPIN = 12000;
+  //A_LONGER_SPIN = 12000;
 
 type
   TSpinModCriticalSection = class(TCriticalSection)
@@ -119,7 +119,7 @@ begin
   for i := Low(LockArray) to High(LockArray) do
   begin
     Locks[i] := TSpinModCriticalSection.Create;
-    Locks[i].SetSpinCount(A_LONGER_SPIN);
+    //Locks[i].SetSpinCount(A_LONGER_SPIN);
   end;
 end;
 

--- a/Common/MemDB/Test/MemDBTestForm.pas
+++ b/Common/MemDB/Test/MemDBTestForm.pas
@@ -4062,20 +4062,32 @@ end;
 type
   TRRThread = class(TThread)
     WaitHandle: TEvent;
+    EntireTablePerTrans: boolean;
     procedure Execute; override;
   end;
 
 procedure TRRThread.Execute;
 var
-  i: integer;
-  j: integer;
+  i, LimI: integer;
+  j, LimJ: integer;
+  idx: integer;
   T: TMemDBTransaction;
   DBAPI: TMemAPIDatabase;
   TblData:TMemAPITableData;
   DataRec: TMemDbFieldDataRec;
 begin
   WaitHandle.WaitFor(INFINITE);
-  for i := 1 to LIMIT do
+  if self.EntireTablePerTrans then
+  begin
+    LimI := 1;
+    LimJ := LIMIT
+  end
+  else
+  begin
+    LimI := LIMIT;
+    LimJ := 1;
+  end;
+  for i := 1 to LimI do
   begin
     T := FSession.StartTransaction(amRead);
     try
@@ -4084,18 +4096,25 @@ begin
         TblData := DBAPI.GetApiObjectFromHandle(
           DBAPI.OpenTableOrKey('Test table'), APITableData) as TMemAPITableData;
         try
-          DataRec.FieldType := ftInteger;
-          j := Succ(Random(LIMIT));
-          DataRec.i32Val := j;
-          TblData.FindByIndex('IntField1Idx', DataRec);
-          TblData.ReadField('IntField1', DataRec);
-          Assert(DataRec.i32Val = j);
-          TblData.ReadField('IntField2', DataRec);
-          Assert(DataRec.i32Val + j = Succ(LIMIT));
-          TblData.ReadField('StringField1', DataRec);
-          Assert(DataRec.sVal = IntToStr(j));
-          TblData.ReadField('StringField2', DataRec);
-          Assert(DataRec.sVal = IntToStr(Succ(LIMIT - j)));
+          for j := 1 to LimJ do
+          begin
+            DataRec.FieldType := ftInteger;
+              if LimJ =1 then
+                idx := Succ(Random(LIMIT))
+              else
+                idx := j;
+              DataRec.i32Val := idx;
+
+            TblData.FindByIndex('IntField1Idx', DataRec);
+            TblData.ReadField('IntField1', DataRec);
+              Assert(DataRec.i32Val = idx);
+            TblData.ReadField('IntField2', DataRec);
+              Assert(DataRec.i32Val + idx = Succ(LIMIT));
+            TblData.ReadField('StringField1', DataRec);
+              Assert(DataRec.sVal = IntToStr(idx));
+            TblData.ReadField('StringField2', DataRec);
+              Assert(DataRec.sVal = IntToStr(Succ(LIMIT - idx)));
+          end;
         finally
           TblData.Free;
         end;
@@ -4113,7 +4132,7 @@ end;
 //get cleared down correctly etc.
 procedure TForm1.MultiRRTrans(Sender: TObject);
 
-  procedure BlastRR;
+  procedure BlastRR(EntireTable: boolean);
   var
     Evt: TEvent;
     Threads: array [0..THREADS_CONCURRENT] of TRRThread;
@@ -4125,6 +4144,7 @@ procedure TForm1.MultiRRTrans(Sender: TObject);
       begin
         Threads[i] := TRRThread.Create(true);
         Threads[i].WaitHandle := Evt;
+        Threads[i].EntireTablePerTrans := EntireTable;
         Threads[i].Resume;
       end;
       Evt.SetEvent;
@@ -4137,7 +4157,10 @@ procedure TForm1.MultiRRTrans(Sender: TObject);
     finally
       Evt.Free;
     end;
-    LogTimeIncr('Multi RR test run OK');
+    if EntireTable then
+      LogTimeIncr('Multi RR test run OK (entire table per transaction)')
+    else
+      LogTimeIncr('Multi RR test run OK (one row per transaction)')
   end;
 
   procedure SetupRR;
@@ -4173,6 +4196,7 @@ procedure TForm1.MultiRRTrans(Sender: TObject);
         DBAPI.Free;
       end;
       T.CommitAndFree;
+      LogTimeIncr('Multi RR test setup table.');
     except
       on E: Exception do
       begin
@@ -4210,6 +4234,7 @@ procedure TForm1.MultiRRTrans(Sender: TObject);
         DBAPI.Free;
       end;
       T.CommitAndFree;
+      LogTimeIncr('Multi RR test filled data.');
     except
       on E: Exception do
       begin
@@ -4223,8 +4248,8 @@ procedure TForm1.MultiRRTrans(Sender: TObject);
 
 begin
   SetupRR;
-  BlastRR;
-  //TODO - More RW transactions / modes etc when they arrive.
+  BlastRR(true);
+  BlastRR(false);
 end;
 
 procedure TForm1.MultiTransClick(Sender: TObject);

--- a/Common/MemDB2/MemDB2Api.pas
+++ b/Common/MemDB2/MemDB2Api.pas
@@ -168,10 +168,7 @@ type
   //API operations. These perform consistency checking on the operations,
   //and do not maintain an per-transaction state.
   TMemDbDatabase = class(TMemDbDatabasePersistent)
-  protected
-    FPolicies: TOptimizePolicies;
   public
-    constructor Create;
     procedure API_CreateTable(T: TObject; Name: string);
     procedure API_CreateForeignKey(T: TObject; Name: string);
     procedure API_RenameTableOrKey(T: TObject; OldName, NewName: string);
@@ -393,9 +390,11 @@ var
    OptSet: TOptimizeSet;
    SizeHint: TDBSizeHint;
    Ctxt: TXEntityLocalContext;
+   TxionSizeEstimate: Int64;
 begin
   FillChar(SizeHint, sizeof(SizeHint), 0);
-  OptSet := MakeOptimizationSet(DB.Policies, Initial, not Initial, false, SizeHint, JournalEntry.Size);
+  GetTxionSizeEstimate(JournalEntry, TxionSizeEstimate);
+  OptSet := MakeOptimizationSet(DB.Policies, Initial, not Initial, false, SizeHint, TxionSizeEstimate);
 
   PseudoTid := TTransactionId.NewTransactionID(ilSerialisable); //if only writer, should be serialisable.
   Ctxt := TXEntityLocalContext.Create;
@@ -945,13 +944,6 @@ end;
 //////////////////////////////////////////////////////////////////////
 
 { TMemDbDatabase }
-
-constructor TMemDBDatabase.Create;
-begin
-  inherited;
-//  FPolicies := NoOptimizePolicies;
-  FPolicies := DefaultOptimizePolicies;
-end;
 
 //Generally, don't try to undelete, unrename etc etc in the same transaction.
 procedure TMemDBDatabase.API_CreateTable(T:TObject; Name: string);

--- a/Common/MemDB2/MemDB2Buffered.pas
+++ b/Common/MemDB2/MemDB2Buffered.pas
@@ -44,11 +44,7 @@ uses
   Trackables,
 {$ENDIF}
   IndexedStore, MemDB2Streamable, Classes, MemDB2Misc, DLList, LockAbstractions,
-  TinyLock, MemDB2BufBase, MemDB2Indexing, Reffed, SyncObjs
-{$IF Defined(MSWINDOWS)}
-  , Windows
-{$ENDIF}
-  ;
+  TinyLock, MemDB2BufBase, MemDB2Indexing, Reffed, SyncObjs;
 
 type
   TMemDBAPIInterfacedObject = class;
@@ -438,6 +434,8 @@ type
     function BuildCheckPartialInternalIndexParallel(Ref1, Ref2: pointer): pointer;
     procedure BuildCheckPartialIndexes(Opts:TOptimizeSet);
 
+    function ThrottleBuildValidateNewIndexParallel(Ref1, Ref2: pointer): pointer;
+    function ThrottleBuildValidateInternalIndexParallel(Ref1, Ref2: pointer): pointer;
     function BuildValidateNewIndexParallel(Ref1, Ref2: pointer): pointer;
     function BuildValidateInternalIndexParallel(Ref1, Ref2: pointer): pointer;
     procedure BuildValidateNewIndexesCommon(LocalIter: boolean; Opts:TOptimizeSet);
@@ -632,7 +630,7 @@ type
   protected
     //Stripe locking performance degrades if more threads than CPU's,
     //because threads become idle holding striped rowlocks. Hence the throttling.
-    FMaxParallel: integer;
+    FPolicies: TOptimizePolicies;
     FEntityThrottle: TSemaphore;
     FIndexThrottle: TSemaphore;
 
@@ -2085,7 +2083,9 @@ end;
 procedure TTidLocal.Init(Parent: TMemDBTablePersistent; const Tid: TTransactionId);
 var
   AddRef: boolean;
+{$IFOPT C+}
   OtherTidLocal: TTidLocal;
+{$ENDIF}
 begin
   FParentTable := Parent;
 
@@ -2421,6 +2421,16 @@ type
   end;
   PBuildValidateIdxParallelContext = ^TBuildValidateIdxParallelContext;
 
+function TTidLocal.ThrottleBuildValidateNewIndexParallel(Ref1, Ref2: pointer): pointer;
+begin
+  FParentTable.FParentDB.FIndexThrottle.Acquire;
+  try
+    result := BuildValidateNewIndexParallel(Ref1, Ref2);
+  finally
+    FParentTable.FParentDB.FIndexThrottle.Release;
+  end;
+end;
+
 function TTidLocal.BuildValidateNewIndexParallel(Ref1, Ref2: pointer): pointer;
 var
   NC: TMemTableMetadataItem;
@@ -2583,6 +2593,16 @@ begin
   end;
 end;
 
+function TTidLocal.ThrottleBuildValidateInternalIndexParallel(Ref1, Ref2: pointer): pointer;
+begin
+  FParentTable.FParentDB.FIndexThrottle.Acquire;
+  try
+    result := BuildValidateInternalIndexParallel(Ref1, Ref2);
+  finally
+    FParentTable.FParentDB.FIndexThrottle.Release;
+  end;
+end;
+
 function TTidLocal.BuildValidateInternalIndexParallel(Ref1, Ref2: pointer): pointer;
 var
   NewIndex: TMemDBIndexInternal;
@@ -2673,6 +2693,23 @@ begin
 
   NewBuild := nil;
   UIdxContext.LocalIter := LocalIter;
+
+  //Re-asses opts, depending on how many indexes we actually need to build
+  //in parallel.
+  PCount := 0;
+  for i := 0 to Pred(Length(FIndexChangesets)) do
+  begin
+    if FIndexChangesets[i] * [ictAdded, ictChangedFieldNumber] <> [] then
+      Inc(PCount);
+  end;
+  if FInternalIndexChangeset * [ictAdded] <> [] then
+    Inc(PCount);
+
+  if PCount <= 1 then
+    Opts := Opts - [optIndexBuildParallel];
+  PCount := 0;
+  //Opt re-assesment done.
+
   if OptApplies(optIndexBuildParallel, Opts) then
     ParallelInit(Handlers, Refs1, Refs2, Excepts, Rets, PCount);
 
@@ -2697,8 +2734,7 @@ begin
       if FIndexChangesets[i] * [ictAdded, ictChangedFieldNumber] <> [] then
       begin
         if OptApplies(optIndexBuildParallel, Opts) then
-          ParallelAddHandler(
-            BuildValidateNewIndexParallel, @UIdxContext, Pointer(i),
+          ParallelAddHandler(ThrottleBuildValidateNewIndexParallel, @UIdxContext, Pointer(i),
             Handlers, Refs1, Refs2, Excepts, Rets, PCount)
         else
           NewBuild.Items[i] := TMemDbIndex(BuildValidateNewIndexParallel(
@@ -2711,8 +2747,7 @@ begin
     begin
       Assert(not Assigned(FInternalIndexCopy)); //Not retrieved from initial index clone.
       if OptApplies(optIndexBuildParallel, Opts) then
-        ParallelAddHandler(
-          BuildValidateInternalIndexParallel, @UIdxContext, nil,
+        ParallelAddHandler(ThrottleBuildValidateInternalIndexParallel, @UIdxContext, nil,
           Handlers, Refs1, Refs2, Excepts, Rets, PCount)
       else
         FInternalIndexCopy := TMemDBIndexInternal(
@@ -3132,6 +3167,35 @@ var
   PCount: integer;
 
 begin
+  //Re-asses opts, depending on how many indexes we actually need to build
+  //in parallel.
+  PCount := 0;
+  //UIdxs.
+  for i := 0 to Pred(FParentTable.FMasterIndexes.Count) do
+  begin
+    if not FIndexingChangeRequired then
+      Inc(PCount)
+    else
+    begin
+      Assert(i < Length(FIndexChangesets));
+      if  FIndexChangesets[i]
+        * [ictAdded, ictDeleted, ictChangedFieldNumber] = [] then
+        Inc(PCount);
+    end;
+  end;
+  //IntIdx.
+  if not FIndexingChangeRequired then
+    Inc(PCount)
+  else
+  begin
+    if FInternalIndexChangeset = [] then
+      Inc(PCount);
+  end;
+  if PCount <= 1 then
+    Opts := Opts - [optIndexEvolveParallel];
+  PCount := 0;
+  //Opt re-assesment done.
+
   if OptApplies(optIndexEvolveParallel, Opts) then
     ParallelInit(Handlers, Refs1, refs2, Excepts, Rets, PCount);
 
@@ -6858,8 +6922,14 @@ var
   Prox: TMemDBEntityProxy;
   Entity: TMemDBEntity;
   i: integer;
+  StartPos, EndPos, i64: int64;
 begin
-  WrTag(Stream, mstDBStart);
+  StartPos := Stream.Position;
+  WrTag(Stream, mstDBStartV2);
+  //Size hint.
+  i64 := 0;
+  Stream.Write(i64, sizeof(i64));
+
   EntityList := AssembleEntityList;
   try
     for i := 0 to Pred(EntityList.Count) do
@@ -6872,6 +6942,18 @@ begin
     EntityList.Release;
   end;
   WrTag(Stream, mstDBEnd);
+
+  //Fixup size hint.
+  //Twist, NullStream really doesn't like being read from.
+  if not (Stream is TNullStream) then
+  begin
+    EndPos := Stream.Position;
+    Stream.Seek(StartPos, soFromBeginning);
+    ExpectTag(Stream, mstDBStartV2);
+    i64 := EndPos - StartPos;
+    Stream.Write(i64, sizeof(i64));
+    Stream.Seek(EndPos, soFromBeginning);
+  end;
 end;
 
 procedure TMemDBDatabasePersistent.ToScratch(const PseudoTid:TTransactionId; Stream: TStream);
@@ -6880,8 +6962,14 @@ var
   Proxy: TMemDbEntityProxy;
   Entity: TMemDbEntity;
   i: integer;
+  StartPos, EndPos, i64: int64;
 begin
-  WrTag(Stream, mstDBStart);
+  StartPos := Stream.Position;
+  WrTag(Stream, mstDBStartV2);
+  //Size hint.
+  i64 := 0;
+  Stream.Write(i64, sizeof(i64));
+
   EntityList := AssembleEntityList;
   try
     for i := 0 to Pred(EntityList.Count) do
@@ -6894,18 +6982,35 @@ begin
     EntityList.Release;
   end;
   WrTag(Stream, mstDBEnd);
+
+  //Fixup size hint.
+  //Twist, NullStream really doesn't like being read from.
+  if not (Stream is TNullStream) then
+  begin
+    EndPos := Stream.Position;
+    Stream.Seek(StartPos, soFromBeginning);
+    ExpectTag(Stream, mstDBStartV2);
+    i64 := EndPos - StartPos;
+    Stream.Write(i64, sizeof(i64));
+    Stream.Seek(EndPos, soFromBeginning);
+  end;
 end;
 
 procedure TMemDBDatabasePersistent.FromJournal(const PseudoTid: TTransactionId; Stream: TStream);
 var
-  StrPos: int64;
+  StrPos, i64: int64;
   NxtTag: TMemStreamTag;
   ChangeType: TMemDBEntityChangeType;
   EntityName: string;
   DBU: TMemDBEntity;
   DBUMeta: TMemDBStreamable;
 begin
-  ExpectTag(Stream, mstDBStart);
+  NxtTag := RdTag(Stream);
+  if not (NxtTag in [mstDBStart, mstDBStartV2]) then
+    raise EMemDBException.Create(S_WRONG_TAG);
+  if (NxtTag = mstDBStartV2) then
+    Stream.Read(i64, sizeof(i64));
+
   StrPos := Stream.Position;
   NxtTag := RdTag(Stream);
   while NxtTag <> mstDBEnd do
@@ -6964,14 +7069,19 @@ end;
 
 procedure TMemDBDatabasePersistent.FromScratch(const PseudoTid: TTransactionId; Stream: TStream; Opts:TOptimizeSet);
 var
-  StrPos: int64;
+  StrPos, i64: int64;
   NxtTag: TMemStreamTag;
   ChangeType: TMemDBEntityChangeType;
   EntityName: string;
   DBU: TMemDBEntity;
   LatestSel: TBufSelector;
 begin
-  ExpectTag(Stream, mstDBStart);
+  NxtTag := RdTag(Stream);
+  if not (NxtTag in [mstDBStart, mstDBStartV2]) then
+    raise EMemDBException.Create(S_WRONG_TAG);
+  if (NxtTag = mstDBStartV2) then
+    Stream.Read(i64, sizeof(i64));
+
   StrPos := Stream.Position;
   NxtTag := RdTag(Stream);
   while NxtTag <> mstDBEnd do
@@ -7317,10 +7427,6 @@ begin
 end;
 
 constructor TMemDBDatabasePersistent.Create;
-{$IF Defined(MSWINDOWS)}
-var
-  SysInfo: TSystemInfo;
-{$ENDIF}
 begin
   inherited;
   FInterfaced := TMemDBAPIInterfacedObject.Create;
@@ -7331,20 +7437,9 @@ begin
   FCommitLock := TCriticalSection.Create;
   FMetaIndexLock := TCriticalSection.Create;
   DLItemInitList(@FEntityList);
-{$IF Defined(MSWINDOWS)}
-  GetSystemInfo(SysInfo);
-  self.FMaxParallel := SysInfo.dwNumberOfProcessors;
-{$ELSE}
-  //TODO - find out how to determine # of CPU's on an appropriate platform.
-  FMaxParallel := 8;
-{$ENDIF}
-  if FMaxParallel < 1 then
-  begin
-    Assert(false);
-    FMaxParallel := 1;
-  end;
-  FEntityThrottle := TSemaphore.Create(nil, FMaxParallel, High(integer), '', false);
-  FIndexThrottle := TSemaphore.Create(nil, FMaxParallel, High(integer), '', false);
+  FPolicies := DefaultOptimizePolicies; //TODO - Configurability here.
+  FEntityThrottle := TSemaphore.Create(nil, FPolicies.MaxParallel, High(integer), '', false);
+  FIndexThrottle := TSemaphore.Create(nil, FPolicies.MaxParallel, High(integer), '', false);
 end;
 
 destructor TMemDBDatabasePersistent.Destroy;

--- a/Common/MemDB2/MemDB2Indexing.pas
+++ b/Common/MemDB2/MemDB2Indexing.pas
@@ -118,36 +118,17 @@ type
     procedure SetFinalFieldOffsets(FinalOffsets: TFieldOffsets);
     procedure SetSparseFieldOffsets(SparseOffsets: TFieldOffsets);
 
-{$IFOPT C+}
-    procedure CheckFastConsistent;
-
-    function GetFinalFieldOffsets: TFieldOffsets;
-    function GetSparseFieldOffsets: TFieldOffsets;
-    function GetFinalFastBase: PFieldOffset;
-    function GetSparseFastBase: PFieldOffset;
-    function GetFinalFastCount: integer;
-    function GetSparseFastCount: integer;
-{$ENDIF}
   public
     destructor Destroy; override;
     function Clone: TMemDBIndexGeneric; override;
     function Find(Sel: TAbSelType; SV: TMemDBIndexSearchVal): TMemDBIndexLeaf;
 
-{$IFOPT C+}
-    property FinalFieldOffsets: TFieldOffsets read GetFinalFieldOffsets write SetFinalFieldOffsets;
-    property SparseFieldOffsets: TFieldOffsets read GetSparseFieldOffsets write SetSparseFieldOffsets;
-    property FinalFastBase: PFieldOffset read GetFinalFastBase;
-    property SparseFastBase: PFieldOffset read GetSparseFastBase;
-    property FinalFastCount: integer read GetFinalFastCount;
-    property SparseFastCount: integer read GetSparseFastCount;
-{$ELSE}
     property FinalFieldOffsets: TFieldOffsets read FFinalFieldOffsets write SetFinalFieldOffsets;
     property SparseFieldOffsets: TFieldOffsets read FSparseFieldOffsets write SetSparseFieldOffsets;
     property FinalFastBase: PFieldOffset read FFinalFastBase;
     property SparseFastBase: PFieldOffset read FSparseFastBase;
     property FinalFastCount: integer read FFinalFastCount;
     property SparseFastCount: integer read FSparseFastCount;
-{$ENDIF}
   end;
 
   TMemDBIndexInternal = class(TMemDBIndexGeneric)
@@ -735,61 +716,11 @@ end;
 
 { TMemDBIndex }
 
-{$IFOPT C+}
-procedure TMemDbIndex.CheckFastConsistent;
-begin
-  Assert(Length(FFinalFieldOffsets) = FFinalFastCount);
-  Assert(Length(FSparseFieldOffsets) = FSparseFastCount);
-  Assert(Assigned(FFinalFastBase) = (FFinalFastCount <> 0));
-  Assert(Assigned(FSparseFastBase) = (FSparseFastCount <> 0));
-end;
-
-function TMemDbIndex.GetFinalFieldOffsets: TFieldOffsets;
-begin
-  CheckFastConsistent;
-  result := FFinalFieldOffsets;
-end;
-
-function TMemDbIndex.GetSparseFieldOffsets: TFieldOffsets;
-begin
-  CheckFastConsistent;
-  result := FSparseFieldOffsets;
-end;
-
-function TMemDbIndex.GetFinalFastBase: PFieldOffset;
-begin
-  CheckFastConsistent;
-  result := FFinalFastBase;
-end;
-
-function TMemDbIndex.GetSparseFastBase: PFieldOffset;
-begin
-  CheckFastConsistent;
-  result := FSparseFastBase;
-end;
-
-function TMemDbIndex.GetFinalFastCount: integer;
-begin
-  CheckFastConsistent;
-  result := FFinalFastCount;
-end;
-
-function TMemDbIndex.GetSparseFastCount: integer;
-begin
-  CheckFastConsistent;
-  result := FSparseFastCount;
-end;
-
-{$ENDIF}
-
 procedure TMemDbIndex.SetFinalFieldOffsets(FinalOffsets: TFieldOffsets);
 var
   NewLen, i: integer;
   WPtr: PFieldOffset;
 begin
-{$IFOPT C+}
-  CheckFastConsistent;
-{$ENDIF}
   FFinalFieldOffsets := FinalOffsets;
   NewLen := Length(FFinalFieldOffsets);
   if NewLen <> FFinalFastCount then
@@ -811,9 +742,6 @@ begin
     WPtr^ := FFinalFieldOffsets[i];
     Inc(WPtr);
   end;
-{$IFOPT C+}
-  CheckFastConsistent;
-{$ENDIF}
 end;
 
 procedure TMemDbIndex.SetSparseFieldOffsets(SparseOffsets: TFieldOffsets);
@@ -821,9 +749,6 @@ var
   NewLen, i: integer;
   WPtr: PFieldOffset;
 begin
-{$IFOPT C+}
-  CheckFastConsistent;
-{$ENDIF}
   FSparseFieldOffsets := SparseOffsets;
   NewLen := Length(FSparseFieldOffsets);
   if NewLen <> FSparseFastCount then
@@ -845,9 +770,6 @@ begin
     WPtr^ := FSparseFieldOffsets[i];
     Inc(WPtr);
   end;
-{$IFOPT C+}
-  CheckFastConsistent;
-{$ENDIF}
 end;
 
 destructor TMemDBIndex.Destroy;
@@ -861,9 +783,6 @@ end;
 
 function TMemDBIndex.Clone: TMemDBIndexGeneric;
 begin
-{$IFOPT C+}
-  CheckFastConsistent;
-{$ENDIF}
   result := inherited;
   if Assigned(result) then
   begin
@@ -874,10 +793,6 @@ begin
       SparseFieldOffsets := self.SparseFieldOffsets;
     end;
   end;
-{$IFOPT C+}
-  CheckFastConsistent;
-  (result as TMemDBIndex).CheckFastConsistent;
-{$ENDIF}
 end;
 
 function TMemDbIndex.Find(Sel: TAbSelType; SV: TMemDBIndexSearchVal): TMemDBIndexLeaf;

--- a/Common/MemDB2/MemDB2Misc.pas
+++ b/Common/MemDB2/MemDB2Misc.pas
@@ -210,7 +210,10 @@ type
   end;
   POptimizePolicy = ^TOptimizePolicy;
 
-  TOptimizePolicies = array [Low(TOptimization).. MaxOptByPolicy] of TOptimizePolicy;
+  TOptimizePolicies = record
+    P: array [Low(TOptimization).. MaxOptByPolicy] of TOptimizePolicy;
+    MaxParallel: integer;
+  end;
 
 const
   TMemDBPhaseStrings: array[TMemDBPhase] of string =
@@ -277,6 +280,9 @@ function DefaultOptimizePolicies: TOptimizePolicies;
 implementation
 
 uses
+{$IF Defined(MSWINDOWS)}
+  Windows,
+{$ENDIF}
   MemDB2Indexing;
 
 const
@@ -314,7 +320,7 @@ begin
   result := [];
   for Opt := Low(Opt) to MaxOptByPolicy do
   begin
-   Policy := @Policies[Opt];
+   Policy := @Policies.P[Opt];
    case Policy.PolicyType of
     optSpecify: DoOpt := Policy.Enabled;
     optContext: DoOpt := (Policy.EnabledReplayFirst and InitFirstTrans) or
@@ -353,31 +359,48 @@ var
 begin
   for Opt := Low(Opt) to High(Opt) do
   begin
-    result[Opt].PolicyType := optSpecify;
-    result[Opt].Enabled := false;
+    result.P[Opt].PolicyType := optSpecify;
+    result.P[Opt].Enabled := false;
   end;
+  result.MaxParallel := 1;
 end;
 
 function DefaultOptimizePolicies: TOptimizePolicies;
+{$IF Defined(MSWINDOWS)}
+var
+  SysInfo: TSystemInfo;
+{$ENDIF}
 begin
-  with result[TOptimization.optEntitiesParallel] do
+  with result.P[TOptimization.optEntitiesParallel] do
   begin
     PolicyType := optTxionSize;
     EnabledRowChangeCount := THIRTY_TWO_K;
     EnabledTxionBufSize := TWO_FIFTY_SIX_K;
     EnabledFKRowsTotal := TWO_FIFTY_SIX_K;
   end;
-  with result[TOptimization.optIndexBuildParallel] do
+  with result.P[TOptimization.optIndexBuildParallel] do
   begin
     PolicyType := optSpecify;
     Enabled := true;
   end;
-  with result[TOptimization.optIndexEvolveParallel] do
+  with result.P[TOptimization.optIndexEvolveParallel] do
   begin
     PolicyType := optTxionSize;
     EnabledRowChangeCount := THIRTY_TWO_K;
     EnabledTxionBufSize := TWO_FIFTY_SIX_K;
     EnabledFKRowsTotal := TWO_FIFTY_SIX_K;
+  end;
+{$IF Defined(MSWINDOWS)}
+  GetSystemInfo(SysInfo);
+  result.MaxParallel := SysInfo.dwNumberOfProcessors;
+{$ELSE}
+  //TODO - find out how to determine # of CPU's on an appropriate platform.
+  result.MaxParallel := 8;
+{$ENDIF}
+  if result.MaxParallel < 1 then
+  begin
+    Assert(false);
+    result.MaxParallel := 1;
   end;
 end;
 
@@ -474,7 +497,7 @@ begin
     inherited;
   finally
     if Length(Tmp) > 0 then
-      DeleteFile(Tmp);
+      SysUtils.DeleteFile(Tmp);
   end;
 end;
 

--- a/Common/MemDB2/MemDB2Streamable.pas
+++ b/Common/MemDB2/MemDB2Streamable.pas
@@ -284,6 +284,7 @@ type
     mstRowStartV2,
     mstGuidStart,
     mstGuidEnd,
+    mstDBStartV2,
     mstReservedForEscape,
     mstReservedForEscape2 //NB, can add after these. No longer FE, FF.
   );
@@ -300,6 +301,8 @@ function RdGuid(Stream:TStream): TGUID;
 
 function AssignedNotSentinel(X: TMemDBStreamable): boolean; inline;
 function NotAssignedOrSentinel(X: TMemDBStreamable): boolean; inline;
+
+procedure GetTxionSizeEstimate(JournalEntry: TStream; var TxionSizeEstimate: int64);
 
 implementation
 
@@ -1270,6 +1273,27 @@ end;
 function NotAssignedOrSentinel(X: TMemDBStreamable): boolean;
 begin
   result := (not Assigned(X)) or (X is TMemDeleteSentinel);
+end;
+
+procedure GetTxionSizeEstimate(JournalEntry: TStream; var TxionSizeEstimate: int64);
+var
+  JPos: int64;
+  Tag: TMemStreamTag;
+begin
+  TxionSizeEstimate := 0;
+  if Assigned(JournalEntry) then
+  begin
+    JPos := JournalEntry.Position;
+    try
+      Tag := RdTag(JournalEntry);
+      if Tag = mstDBStartV2 then
+        JournalEntry.Read(TxionSizeEstimate, sizeof(TxionSizeEstimate))
+      else
+        TxionSizeEstimate := JournalEntry.Size - JournalEntry.Position;
+    finally
+      JournalEntry.Seek(JPos, soFromBeginning);
+    end;
+  end;
 end;
 
 end.

--- a/Common/MemDB2/Test/MemDB2TestForm.pas
+++ b/Common/MemDB2/Test/MemDB2TestForm.pas
@@ -4171,20 +4171,32 @@ type
     WaitHandle: TEvent;
     RMode: TMDBAccessMode;
     Iso: TMDBIsolationLevel;
+    EntireTablePerTrans: boolean;
     procedure Execute; override;
   end;
 
 procedure TRRThread.Execute;
 var
-  i: integer;
-  j: integer;
+  i, LimI: integer;
+  j, LimJ: integer;
+  idx: integer;
   T: TMemDBTransaction;
   DBAPI: TMemAPIDatabase;
   TblData:TMemAPITableData;
   DataRec: TMemDbFieldDataRec;
 begin
   WaitHandle.WaitFor(INFINITE);
-  for i := 1 to LIMIT do
+  if self.EntireTablePerTrans then
+  begin
+    LimI := 1;
+    LimJ := LIMIT
+  end
+  else
+  begin
+    LimI := LIMIT;
+    LimJ := 1;
+  end;
+  for i := 1 to LimI do
   begin
     T := FSession.StartTransaction(RMode, amLazyWrite, Iso);
     try
@@ -4192,18 +4204,25 @@ begin
       try
         TblData := DBAPI.GetAPIObjectFromEntity('Test table', APITableData) as TMemAPITableData;
         try
-          DataRec.FieldType := ftInteger;
-          j := Succ(Random(LIMIT));
-          DataRec.i32Val := j;
-          TblData.FindByIndex('IntField1Idx', DataRec);
-          TblData.ReadField('IntField1', DataRec);
-          Assert(DataRec.i32Val = j);
-          TblData.ReadField('IntField2', DataRec);
-          Assert(DataRec.i32Val + j = Succ(LIMIT));
-          TblData.ReadField('StringField1', DataRec);
-          Assert(DataRec.sVal = IntToStr(j));
-          TblData.ReadField('StringField2', DataRec);
-          Assert(DataRec.sVal = IntToStr(Succ(LIMIT - j)));
+          for j := 1 to LimJ do
+          begin
+            DataRec.FieldType := ftInteger;
+            if LimJ =1 then
+              idx := Succ(Random(LIMIT))
+            else
+              idx := j;
+            DataRec.i32Val := idx;
+
+            TblData.FindByIndex('IntField1Idx', DataRec);
+            TblData.ReadField('IntField1', DataRec);
+            Assert(DataRec.i32Val = idx);
+            TblData.ReadField('IntField2', DataRec);
+            Assert(DataRec.i32Val + idx = Succ(LIMIT));
+            TblData.ReadField('StringField1', DataRec);
+            Assert(DataRec.sVal = IntToStr(idx));
+            TblData.ReadField('StringField2', DataRec);
+            Assert(DataRec.sVal = IntToStr(Succ(LIMIT - idx)));
+          end;
         finally
           TblData.Free;
         end;
@@ -4221,7 +4240,7 @@ end;
 //get cleared down correctly etc.
 procedure TForm1.MultiRRTrans(Sender: TObject);
 
-  procedure BlastRR;
+  procedure BlastRR(EntireTable: boolean);
   var
     Evt: TEvent;
     Threads: array [0..THREADS_CONCURRENT] of TRRThread;
@@ -4235,6 +4254,7 @@ procedure TForm1.MultiRRTrans(Sender: TObject);
         Threads[i].WaitHandle := Evt;
         Threads[i].RMode := self.RMode;
         Threads[i].Iso := self.Iso;
+        Threads[i].EntireTablePerTrans := EntireTable;
         Threads[i].Resume;
       end;
       Evt.SetEvent;
@@ -4247,7 +4267,10 @@ procedure TForm1.MultiRRTrans(Sender: TObject);
     finally
       Evt.Free;
     end;
-    LogTimeIncr('Multi RR test run OK');
+    if EntireTable then
+      LogTimeIncr('Multi RR test run OK (entire table per transaction)')
+    else
+      LogTimeIncr('Multi RR test run OK (one row per transaction)')
   end;
 
   procedure SetupRR;
@@ -4282,6 +4305,7 @@ procedure TForm1.MultiRRTrans(Sender: TObject);
         DBAPI.Free;
       end;
       T.CommitAndFree;
+      LogTimeIncr('Multi RR test setup table.');
     except
       on E: Exception do
       begin
@@ -4318,6 +4342,7 @@ procedure TForm1.MultiRRTrans(Sender: TObject);
         DBAPI.Free;
       end;
       T.CommitAndFree;
+      LogTimeIncr('Multi RR test filled data.');
     except
       on E: Exception do
       begin
@@ -4331,8 +4356,8 @@ procedure TForm1.MultiRRTrans(Sender: TObject);
 
 begin
   SetupRR;
-  BlastRR;
-  //TODO - More RW transactions / modes etc when they arrive.
+  BlastRR(true);
+  BlastRR(false);
 end;
 
 procedure TForm1.MultiTransClick(Sender: TObject);

--- a/Overall TODO.txt
+++ b/Overall TODO.txt
@@ -1,16 +1,24 @@
 
 MemDB2 TODO.
 
-- VTune straight line performance. Okay, but not fab.
-  Unfortunately locking does kinda slow stuff down, unavoidable.
+- Lots of small transactions reading one row is very slow
+  - 1024 tx start par thread x 64 threads takes 30 secs.
+    - even when commit / rollback etc does not spawn threads?
+      only one row changed per thread?
 
-- Parallelise.
+- As opposed to 64 tx start, 1024 rows per tx, is 1 sec
+  (as fast as 1 serial thread ... expect metadata serialisation)
+  but should be able to do it in prob 1/8th second
 
 - Refactor META_ / Pinning functions to use cached values.
   - Todo: Debug bad multi-reader performance, see if this is indeed the cause.
 
-- Create GetCurrentInLock / GetNextInLock function for faster access under commit lock.
-  - Only where definitely possible (perhaps not GetNext as it's not an immutable part of the list).
+- Have CurrentInLock function.
+  - Check not duplicated work with FLagsInLock.
+  - Create boolean test flag for InLock
+    - Global, and MemDBTest only.
+  - Look for instances of PinCurrent durring commit cycle where clearly
+    not needed.
 
 - MinIso values  / require atomic. Way to make that cleaner?
   - More careful scrutiny on what requires meta to be atomic and when.


### PR DESCRIPTION
MemDB2: Improve test routines for simultaneous transactions, start looking into it. MemDB2: Improve index build single-threaded. Thats it for parallel index build craziness. MemDB2:Remove FastOffsets debug checking.
MemDB2: Improve transaction size estimates.
MemDB2: Sort spin count, DB policies, max threadcount.