### PR TITLE
MemDB2: Metadata caching and multi-thread write testcases.

### DIFF
--- a/Common/LockAbstractions/TinyLock.pas
+++ b/Common/LockAbstractions/TinyLock.pas
@@ -37,7 +37,7 @@ implementation
 uses LockAbstractions, SysUtils;
 
 const
-  SPIN_COUNT = 200;
+  SPIN_COUNT = 2000; //Default spin count for windows spinlocks.
 
 procedure AcquireTinyLock(var Lock: TTinyLock);
 var
@@ -51,8 +51,9 @@ begin
       if LockAbstractions.InterlockedCompareExchange(Integer(Lock), 1, 0) = 0 then
         exit;
       Dec(Tries);
+      YieldProcessor;
     end;
-    Sleep(0); //Yield.
+    Sleep(0); //A bigger yield.
   end;
 end;
 

--- a/Common/MemDB2/MemDB2Api.pas
+++ b/Common/MemDB2/MemDB2Api.pas
@@ -108,6 +108,7 @@ type
     FAdding: boolean;
     FFieldList: TMemStreamableList;
     FFieldListDirty: boolean;
+    FTidLocalHint: TTidLocal;
   protected
     procedure DiscardInternal;
   public
@@ -190,11 +191,6 @@ type
     //Unfortunately, very first touch/pin of metadata needs to be by TidLocal, so that
     //CC fields/indexes are in sync with TidLocal index roots, hence all the wrapping here.
 
-    //TODO - Optimise the use of these META functions, so that we don't need
-    // to repeatedly query for the TidLocal structure.
-
-    procedure META_CurIndexDefToFieldDefs(const Tid: TTransactionId; IndexDef: TMemIndexDef; var FieldDefs: TMemFieldDefs; var FieldAbsIdxs: TFieldOffsets);
-    function META_CurFieldDefList(const Tid: TTransactionId): TMemStreamableList;
   public
     procedure API_CreateField(T: TObject; Name: string; FieldType: TMDBFieldType);
     procedure API_DeleteField(T: TObject; Name: string);
@@ -214,36 +210,44 @@ type
     function API_GetIndexNames(T: TObject): TStringList;
 
     function API_DataLocate(T:TObject;
+                            TidLocalHint: TTidLocal;
                             Cursor: TMemDBCursor;
                             Pos: TMemAPIPosition;
                             IdxName: string): TMemDBCursor; //Returns cursor.
 
     function API_DataFindByIndex(T: TObject;
+                                TidLocalHint: TTidLocal;
                                 IdxName: string;
                                 const DataRecs: TMemDbFieldDataRecs): TMemDBCursor; //Returns cursor
 
     function API_DataFindEdgeByIndex(T:TObject;
+                                     TidLocalHint: TTidLocal;
                                      IdxName: string;
                                      const DataRecs: TMemDbFieldDataRecs;
                                      Pos: TMemAPIPosition): TMemDBCursor; //Returns cursor.
 
     procedure API_DataReadRow(T:TObject;
+                             TidLocalHint: TTidLocal;
                              Cursor: TMemDBCursor;
                              FieldList: TMemStreamableList);
 
     procedure API_DataInitRowForAppend(T: TObject;
+                                      TidLocalHint: TTidLocal;
                                       Cursor: TMemDBCursor;
                                       FieldList: TMemStreamableList);
 
     function API_DataRowModOrAppend(T: TObject;
+                                    TidLocalHint: TTidLocal;
                                     Cursor: TMemDBCursor;
                                     FieldList: TMemStreamableList): TMemDBCursor;
 
     function API_DataRowDelete(T: TObject;
+                               TidLocalHint: TTidLocal;
                                Cursor: TMemDBCursor;
                                AutoInc: boolean): TMemDBCursor;
 
     function API_DataGetFieldAbsIdx(T: TObject;
+                                    TidLocalHint: TTidLocal;
                                     FieldName: string): integer;
 
   public
@@ -314,7 +318,6 @@ const
   S_API_INDEX_MUST_HAVE_FIELDS = 'You must specify some fields to index on';
   S_API_INTERNAL_TAG_DATA_BAD = 'Index does not correspond with a valid tag';
   S_API_INTERNAL_READING_ROW = 'Internal error reading row data.';
-  S_API_TABLE_METADATA_NOT_COMMITED = 'No committed metadata for this table (api level)';
   S_API_INTERNAL_CHANGING_ROW = 'Internal error changing row data.';
   S_API_ROW_BAD_STRUCTURE = 'Error changing row, field layout different from table.';
   S_API_SEARCH_REQUIRES_INDEX = 'Bad index name, or index not found, comitted indices only.';
@@ -723,7 +726,7 @@ var
   NCursor:TMemDBCursor;
 begin
   DiscardInternal;
-  NCursor := Table.API_DataLocate(FAssociatedTransaction, FCursor, Pos, IdxName);
+  NCursor := Table.API_DataLocate(FAssociatedTransaction, FTidLocalHint, FCursor, Pos, IdxName);
   if NCursor <> FCursor then
   begin
     FCursor.Free;
@@ -731,7 +734,7 @@ begin
   end;
   result := Assigned(FCursor);
   if result then
-    Table.API_DataReadRow(FAssociatedTransaction, FCursor, FFieldList);
+    Table.API_DataReadRow(FAssociatedTransaction, FTidLocalHint, FCursor, FFieldList);
 end;
 
 
@@ -752,7 +755,7 @@ var
   NCursor:TMemDBCursor;
 begin
   DiscardInternal;
-  NCursor := Table.API_DataFindByIndex(FAssociatedTransaction, IdxName, DataRecs);
+  NCursor := Table.API_DataFindByIndex(FAssociatedTransaction, FTidLocalHint, IdxName, DataRecs);
   if NCursor <> FCursor then
   begin
     FCursor.Free;
@@ -760,7 +763,7 @@ begin
   end;
   result := Assigned(FCursor);
   if result then
-    Table.API_DataReadRow(FAssociatedTransaction, FCursor, FFieldList);
+    Table.API_DataReadRow(FAssociatedTransaction, FTidLocalHint, FCursor, FFieldList);
 end;
 
 function TMemAPITableData.FindEdgeByIndex(Pos: TMemAPIPosition; IdxName: string;
@@ -779,7 +782,7 @@ var
   NCursor:TMemDBCursor;
 begin
   DiscardInternal;
-  NCursor := Table.API_DataFindEdgeByIndex(FAssociatedTransaction,
+  NCursor := Table.API_DataFindEdgeByIndex(FAssociatedTransaction, FTidLocalHint,
                                            IdxName, DataRecs, Pos);
   if NCursor <> FCursor then
   begin
@@ -788,7 +791,7 @@ begin
   end;
   result := Assigned(FCursor);
   if result then
-    Table.API_DataReadRow(FAssociatedTransaction, FCursor, FFieldList);
+    Table.API_DataReadRow(FAssociatedTransaction, FTidLocalHint, FCursor, FFieldList);
 end;
 
 procedure TMemAPITableData.Append;
@@ -798,7 +801,7 @@ begin
   FCursor.Free;
   FCursor := nil;
   FAdding := true;
-  Table.API_DataInitRowForAppend(FAssociatedTransaction, FCursor, FFieldList);
+  Table.API_DataInitRowForAppend(FAssociatedTransaction, FTidLocalHint, FCursor, FFieldList);
   //No point reading, fields all zero.
 end;
 
@@ -813,7 +816,7 @@ begin
     raise EMemDBAPIException.Create(S_API_NO_ROW_SELECTED);
   if FFieldList.Count = 0 then
     raise EMemDBAPiException.Create(S_API_NO_FIELDS_DUP_POST_OR_DISCARD);
-  FieldAbsIdx := Table.API_DataGetFieldAbsIdx(FAssociatedTransaction, FieldName);
+  FieldAbsIdx := Table.API_DataGetFieldAbsIdx(FAssociatedTransaction, FTidLocalHint, FieldName);
   if (FieldAbsIdx < 0) or (FieldAbsIdx >= FFieldList.Count) then
     raise EMemDBInternalException.Create(S_API_BAD_FIELD_INDEX);
   MemFieldData := (FFieldList.Items[FieldAbsIdx] as TMemFieldData);
@@ -867,7 +870,7 @@ begin
     raise EMemDBAPIException.Create(S_API_NO_ROW_SELECTED);
   if FFieldList.Count = 0 then
     raise EMemDBAPiException.Create(S_API_NO_FIELDS_DUP_POST_OR_DISCARD);
-  FieldAbsIdx := Table.API_DataGetFieldAbsIdx(FAssociatedTransaction, FieldName);
+  FieldAbsIdx := Table.API_DataGetFieldAbsIdx(FAssociatedTransaction, FTidLocalHint, FieldName);
   if (FieldAbsIdx < 0) or (FieldAbsIdx >= FFieldList.Count) then
     raise EMemDBInternalException.Create(S_API_BAD_FIELD_INDEX);
   Field := (FFieldList.Items[FieldAbsIdx] as TMemFieldData);
@@ -909,7 +912,7 @@ var
 begin
   CheckWriteTransaction;
   //Do the post.
-  NewCursor := Table.API_DataRowModOrAppend(FAssociatedTransaction, FCursor, FFieldList);
+  NewCursor := Table.API_DataRowModOrAppend(FAssociatedTransaction, FTidLocalHint, FCursor, FFieldList);
   Discard;
   Assert(NewCursor <> FCursor);
   FCursor.Free;
@@ -925,12 +928,12 @@ begin
     raise EMemDBAPIException.Create(S_API_NO_ROW_SELECTED);
 
   Discard;
-  NextCursor := Table.API_DataRowDelete(FAssociatedTransaction, FCursor, AutoInc);
+  NextCursor := Table.API_DataRowDelete(FAssociatedTransaction, FTidLocalHint, FCursor, AutoInc);
   Assert(NextCursor <> FCursor);
   FCursor.Free;
   FCursor := NextCursor;
   if Assigned(FCursor) then
-    Table.API_DataReadRow(FAssociatedTransaction, FCursor, FFieldList);
+    Table.API_DataReadRow(FAssociatedTransaction, FTidLocalHint, FCursor, FFieldList);
 end;
 
 function TMemAPITableData.RowSelected: boolean;
@@ -1072,7 +1075,7 @@ begin
 
   try
     //AB sel might be current (committed), not next.
-    RefNext := Entity.META_GetNext(Tr.Tid);
+    RefNext := Entity.Metadata.GetNext(Tr.Tid);
     if Assigned(RefNext) and (RefNext is TMemDeleteSentinel) then
       raise EMemDbAPIException.Create(S_API_ENTITY_NAME_NOT_FOUND);
 
@@ -1093,8 +1096,8 @@ begin
       raise EMemDBAPIException.Create(S_API_RENAME_OVERWRITE);
     end;
 
-    Entity.META_RequestChange(Tr.Tid);
-    NextM := Entity.META_GetNext(Tr.Tid);
+    Entity.Metadata.RequestChange(Tr.Tid);
+    NextM := Entity.Metadata.GetNext(Tr.Tid);
     Assert((not Assigned(RefNext)) or (RefNext = NextM));
     Assert(not (NextM is TMemDeleteSentinel));
     (NextM as TMemEntityMetadataItem).EntityName := NewName;
@@ -1120,7 +1123,7 @@ begin
     //Referenced by anything else?
     if Entity is TMemDbTablePersistent then
       CheckAPITableDelete(Tr.Tid, Tr.LocalContext, Name);
-    Entity.META_Delete(Tr.Tid);
+    Entity.Metadata.Delete(Tr.Tid);
   finally
     Entity.Proxy.Release;
   end;
@@ -1141,7 +1144,6 @@ var
 
 begin
   Tr := T as TMemDbTransaction;
-  AB := MakeLatestBufSelector(Tr.Tid);
   result := TStringList.Create;
   CtxtLocal := Tr.LocalContext;
 
@@ -1151,14 +1153,7 @@ begin
     begin
       Proxy := EList.Items[i] as TMemDBEntityProxy;
       Entity := Proxy.Proxy as TMemDBEntity;
-      case AB.SelType of
-        abCurrent: MDReffed := Entity.META_PinCurrent(AB.TId, pinEvolve);
-        abNext: MDReffed := Entity.META_GetNext(AB.TId);
-        abLatest: MDReffed := Entity.META_GetPinLatest(AB.TId, tmpBufSel, pinEvolve);
-      else
-        Assert(false);
-        MdReffed := nil;
-      end;
+      MDReffed := Entity.Metadata.GetPinLatest(Tr.TId, tmpBufSel, pinEvolve);
       if AssignedNotSentinel(MDReffed as TMemDbStreamable) then
       begin
         MdItem := MDReffed as TMemEntityMetadataItem;
@@ -1184,6 +1179,11 @@ begin
   begin
     try
       result := Entity.Interfaced.GetAPIObject(Tr, API, false);
+      if Assigned(result) and (result is TMemAPITableData) then
+      begin
+        (result as TMemAPITableData).FTidLocalHint
+          := (Entity as TMemDBTablePersistent).GetOptTidLocal(Tr.Tid);
+      end;
     finally
       Entity.Proxy.Release;
     end;
@@ -1217,7 +1217,7 @@ var
 begin
   Tr := T as TMemDbTransaction;
   Sel := MakeLatestBufSelector(Tr.Tid);
-  if Assigned(META_FieldByName(Sel, Name, tmpIdx)) then
+  if Assigned(FieldByName(Sel, Name, tmpIdx, PinEvolve)) then
     raise EMemDBAPIException.Create(S_API_FIELD_NAME_CONFLICT);
   //Do data manipulation with list helper.
   TidLocal := GetMakeListHelpers(Tr.Tid, FieldHelper, IndexHelper);
@@ -1247,7 +1247,7 @@ var
 begin
   Tr := T as TMemDbTransaction;
   Sel := MakeLatestBufSelector(Tr.Tid);
-  Field := META_FieldByName(Sel, Name, FieldIdx);
+  Field := FieldByName(Sel, Name, FieldIdx, PinEvolve);
   if not Assigned(Field) then
     raise EMemDBAPIException.Create(S_API_FIELD_NAME_NOT_FOUND);
   TidLocal := GetMakeListHelpers(Tr.Tid, FieldHelper, IndexHelper);
@@ -1287,18 +1287,18 @@ var
 begin
   Tr := T as TMemDbTransaction;
   Sel := MakeLatestBufSelector(Tr.Tid);
-  Field := META_FieldByName(Sel, OldName, FieldIdx);
+  Field := FieldByName(Sel, OldName, FieldIdx, PinEvolve);
   TidLocal := GetMakeListHelpers(Tr.Tid, FieldHelper, IndexHelper);
   if (not Assigned(Field)) or (FieldHelper.ChildDeleted[FieldIdx]) then
     raise EMemDBAPIException.Create(S_API_FIELD_NAME_NOT_FOUND);
-  if Assigned(META_FieldByName(Sel, NewName, tmpIdx)) then
+  if Assigned(FieldByName(Sel, NewName, tmpIdx, PinEvolve)) then
     raise EMemDBAPIException.Create(S_API_FIELD_NAME_CONFLICT);
-  if AssignedNotSentinel(META_GetNext(Tr.Tid)) then
+  if AssignedNotSentinel(Metadata.GetNext(Tr.Tid)) then
   begin
     //Check there has not been a previous conflicting rename.
     //If previously been deleted, ChildDeleted check above should fail.
-    Assert (AssignedNotSentinel((META_GetNext(Tr.Tid) as TMemTableMetadataItem).FieldDefs.Items[FieldIdx]));
-    Field := (META_GetNext(Tr.Tid) as TMemTableMetadataItem).FieldDefs.Items[FieldIdx]
+    Assert (AssignedNotSentinel((Metadata.GetNext(Tr.Tid) as TMemTableMetadataItem).FieldDefs.Items[FieldIdx]));
+    Field := (Metadata.GetNext(Tr.Tid) as TMemTableMetadataItem).FieldDefs.Items[FieldIdx]
       as TMemFieldDef;
     if Field.FieldName <> OldName then
       raise EMemDBAPIException.Create(S_API_RENAME_OVERWRITE);
@@ -1332,7 +1332,7 @@ var
 begin
   Tr := T as TMemDbTransaction;
   Sel := MakeLatestBufSelector(Tr.Tid);
-  Field := META_FieldByName(Sel, Name, FieldIdx);
+  Field := FieldByName(Sel, Name, FieldIdx, PinEvolve);
   result := Assigned(Field);
   if result then
     FieldType := Field.FieldType;
@@ -1348,9 +1348,9 @@ var
 begin
   Tr := T as TMemDbTransaction;
   result := TStringList.Create;
-  if AssignedNotSentinel(META_GetPinLatest(Tr.Tid, Selected, pinEvolve)) then
+  if AssignedNotSentinel(Metadata.GetPinLatest(Tr.Tid, Selected, pinEvolve)) then
   begin
-    MetadataCopy := META_GetPinLatest(Tr.Tid, Selected, pinEvolve) as TMemTableMetadataItem;
+    MetadataCopy := Metadata.GetPinLatest(Tr.Tid, Selected, pinEvolve) as TMemTableMetadataItem;
     for idx := 0 to Pred(MetadataCopy.FieldDefs.Count) do
     begin
       if AssignedNotSentinel(MetadataCopy.FieldDefs.Items[idx]) then
@@ -1380,12 +1380,12 @@ begin
   Sel := MakeLatestBufSelector(Tr.Tid);
   if Length(Name) = 0 then
     raise EMemDBAPIException.Create(S_API_INDEX_NAME_NULL);
-  if Assigned(META_IndexByName(Sel, Name, IndexIdx)) then
+  if Assigned(IndexByName(Sel, Name, IndexIdx, PinEvolve)) then
     raise EMemDBAPIException.Create(S_API_INDEX_NAME_CONFLICT);
   if Length(IndexedFields) = 0 then
     raise EMemDbApiException.Create(S_API_INDEX_MUST_HAVE_FIELDS);
   Sel := MakeLatestBufSelector(Tr.Tid);
-  Fields := META_FieldsByNames(Sel, IndexedFields, FieldAbsIdxs);
+  Fields := FieldsByNames(Sel, IndexedFields, FieldAbsIdxs, PinEvolve);
   if Length(Fields) = 0 then
     raise EMemDBAPIException.Create(S_API_FIELD_NAME_NOT_FOUND);
   Assert(Length(Fields) = Length(IndexedFields));
@@ -1424,11 +1424,11 @@ begin
   Tr := T as TMemDbTransaction;
   Sel := MakeLatestBufSelector(Tr.Tid);
   TidLocal := GetMakeListHelpers(Tr.Tid, FieldHelper, IndexHelper);
-  Index := META_IndexByName(Sel, Name, IndexIdx);
+  Index := IndexByName(Sel, Name, IndexIdx, PinEvolve);
   if not Assigned(Index) then
     raise EMemDbAPIException.Create(S_API_INDEX_NAME_NOT_FOUND);
-  Assert(AssignedNotSentinel(META_GetPinLatest(Tr.Tid, Selected, pinEvolve)));
-  MT := META_GetPinLatest(Tr.Tid, Selected, pinEvolve) as TMemTableMetadataItem;
+  Assert(AssignedNotSentinel(Metadata.GetPinLatest(Tr.Tid, Selected, pinEvolve)));
+  MT := Metadata.GetPinLatest(Tr.Tid, Selected, pinEvolve) as TMemTableMetadataItem;
   ParentDB.CheckAPIIndexDelete(Tr.Tid, Tr.LocalContext,  MT.EntityName, Name);
   //Delete index.
   IndexHelper.Delete(IndexIdx);
@@ -1448,18 +1448,18 @@ var
 begin
   Tr := T as TMemDBTransaction;
   Sel := MakeLatestBufSelector(Tr.Tid);
-  Index := META_IndexByName(Sel, OldName, IndexIdx);
+  Index := IndexByName(Sel, OldName, IndexIdx, PinEvolve);
   TidLocal := GetMakeListHelpers(Tr.Tid, FieldHelper, IndexHelper);
   if (not Assigned(Index)) or (IndexHelper.ChildDeleted[IndexIdx]) then
     raise EMemDBAPIException.Create(S_API_INDEX_NAME_NOT_FOUND);
-  if Assigned(META_IndexByName(Sel, NewName, tmpIdx)) then
+  if Assigned(IndexByName(Sel, NewName, tmpIdx, PinEvolve)) then
     raise EMemDBAPIException.Create(S_API_INDEX_NAME_CONFLICT);
-  if AssignedNotSentinel(META_GetNext(Tr.Tid)) then
+  if AssignedNotSentinel(Metadata.GetNext(Tr.Tid)) then
   begin
     //Check there has not been a previous conflicting rename.
     //If previously been deleted, ChildDeleted check above should fail.
-    Assert(AssignedNotSentinel((META_GetNext(Tr.Tid) as TMemTableMetadataItem).IndexDefs.Items[IndexIdx]));
-    Index := (META_GetNext(Tr.Tid) as TMemTableMetadataItem).IndexDefs.Items[IndexIdx]
+    Assert(AssignedNotSentinel((Metadata.GetNext(Tr.Tid) as TMemTableMetadataItem).IndexDefs.Items[IndexIdx]));
+    Index := (Metadata.GetNext(Tr.Tid) as TMemTableMetadataItem).IndexDefs.Items[IndexIdx]
       as TMemIndexDef;
     if Index.IndexName <> OldName then
       raise EMemDBAPIException.Create(S_API_RENAME_OVERWRITE);
@@ -1467,9 +1467,9 @@ begin
   //Now rename the index.
   Index := IndexHelper.Modify(IndexIdx) as TMemIndexDef;
   Index.IndexName := NewName;
-  Assert(AssignedNotSentinel(META_GetPinLatest(Tr.Tid, selected, pinEvolve)));
+  Assert(AssignedNotSentinel(Metadata.GetPinLatest(Tr.Tid, selected, pinEvolve)));
   ParentDB.HandleAPIIndexRename(Tr.Tid, Tr.LocalContext,
-    (META_GetPinLatest(Tr.Tid, selected, pinEvolve) as TMemTableMetadataItem).EntityName,
+    (Metadata.GetPinLatest(Tr.Tid, selected, pinEvolve) as TMemTableMetadataItem).EntityName,
     OldName, NewName);
   TidLocal.UpdateLayout(pinEvolve);
 end;
@@ -1486,7 +1486,7 @@ var
 begin
   Tr := T as TMemDbTransaction;
   Sel := MakeLatestBufSelector(Tr.Tid);
-  Index := META_IndexByName(Sel, Name, IndexIdx);
+  Index := IndexByName(Sel, Name, IndexIdx, PinEvolve);
   result := Assigned(Index);
   if result then
   begin
@@ -1507,9 +1507,9 @@ var
 begin
   result := TStringList.Create;
   Tr := T as TMemDbTransaction;
-  if AssignedNotSentinel(META_GetPinLatest(Tr.Tid, selected, pinEvolve)) then
+  if AssignedNotSentinel(Metadata.GetPinLatest(Tr.Tid, selected, pinEvolve)) then
   begin
-    MetadataCopy := META_GetPinLatest(Tr.Tid, selected, pinEvolve) as TMemTableMetadataItem;
+    MetadataCopy := Metadata.GetPinLatest(Tr.Tid, selected, pinEvolve) as TMemTableMetadataItem;
     for idx := 0 to Pred(MetadataCopy.IndexDefs.Count) do
     begin
       if AssignedNotSentinel(MetadataCopy.IndexDefs.Items[idx]) then
@@ -1536,30 +1536,8 @@ begin
   end;
 end;
 
-procedure TMemDBTable.META_CurIndexDefToFieldDefs(const Tid: TTransactionId; IndexDef: TMemIndexDef; var FieldDefs: TMemFieldDefs; var FieldAbsIdxs: TFieldOffsets);
-var
-  Sel: TBufSelector;
-begin
-  Assert(Assigned(IndexDef));
-  Assert(IndexDef.FieldNameCount > 0);
-  Sel := MakeCurrentBufSelector(Tid);
-  FieldDefs := META_FieldsByNames(Sel, IndexDef.FieldArray, FieldAbsIdxs);
-end;
-
-function TMemDBTable.META_CurFieldDefList(const Tid: TTransactionId): TMemStreamableList;
-var
-  CB: TMemDBStreamable;
-  CurMetadata: TMemTableMetadataItem;
-begin
-  CB := META_PinCurrent(Tid, pinEvolve);
-  if NotAssignedOrSentinel(CB) then
-    raise EMemDBAPIException.Create(S_API_TABLE_METADATA_NOT_COMMITED);
-  CurMetadata := CB as TMemTableMetadataItem;
-  result := CurMetadata.FieldDefs;
-end;
-
-//TODO - Ensure debug / logging builds do in fact build.
 function TMemDBTable.API_DataLocate(T:TObject;
+                        TidLocalHint: TTidLocal;
                         Cursor: TMemDBCursor;
                         Pos: TMemAPIPosition;
                         IdxName: string): TMemDBCursor;
@@ -1567,18 +1545,15 @@ var
   IRoot: TMemDBIndexGeneric;
   Idx: TMemIndexDef;
   Tr: TMemDBTransaction;
-  TidLocal: TTidLocal;
 begin
   Tr := T as TMemDBTransaction;
+  Assert(Tr.Tid = TidLocalHint.Tid);
   if (Length(IdxName) = 0) and (Tr.Tid.Iso < ilSnapshot) then
-  begin
-    IRoot := nil;
-    TidLocal := GetTidLocal(Tr.Tid);
-  end
+    IRoot := nil
   else
   begin
     //Use internal index at snapshot iso and above.
-    IRoot := GetUserTidLocalIndexRoot(Tr.Tid, TidLocal, Idx, IdxName);
+    IRoot := GetUserTidLocalIndexRoot(TidLocalHint, Idx, IdxName);
     if not Assigned(IRoot) then
       raise EMemDBAPIException.Create(S_API_SEARCH_REQUIRES_INDEX);
   end;
@@ -1596,11 +1571,12 @@ begin
       + ' Index name: ' + IdxName);
   end;
 {$ENDIF}
-  result := TidLocal.UserMoveToRowByIndexRoot(IRoot, Cursor, Pos);
+  result := TidLocalHint.UserMoveToRowByIndexRoot(IRoot, Cursor, Pos);
 end;
 
 
 function TMemDBTable.API_DataFindByIndex(T:TObject;
+                            TidLocalHint: TTidLocal;
                             IdxName: string;
                             const DataRecs: TMemDbFieldDataRecs): TMemDbCursor; //Returns cursor
 var
@@ -1608,7 +1584,6 @@ var
   IRoot: TMemDBIndex;
   Idx: TMemIndexDef;
   Tr: TMemDBTransaction;
-  TidLocal: TTidLocal;
   FieldDefs: TMemFieldDefs;
   FieldAbsIdxs: TFieldOffsets;
 
@@ -1617,10 +1592,11 @@ var
 {$ENDIF}
 begin
   Tr := T as TMemDBTransaction;
+  Assert(Tr.Tid = TidLocalHint.Tid);
   if Length(IdxName) = 0 then
     raise EMemDBAPIException.Create(S_API_SEARCH_REQUIRES_INDEX);
 
-  IRootGeneric := GetUserTidLocalIndexRoot(Tr.Tid, TidLocal, Idx, IdxName);
+  IRootGeneric := GetUserTidLocalIndexRoot(TidLocalHint, Idx, IdxName);
   if not Assigned(IRootGeneric) then
     raise EMemDBAPIException.Create(S_API_SEARCH_REQUIRES_INDEX);
 
@@ -1629,7 +1605,7 @@ begin
   IRoot := IRootGeneric as TMemDBIndex;
   Assert(Assigned(Idx));
 
-  META_CurIndexDefToFieldDefs(Tr.Tid, Idx, FieldDefs, FieldAbsIdxs);
+  TidLocalHint.META_CurIndexDefToFieldDefs(Idx, FieldDefs, FieldAbsIdxs);
   if Length(DataRecs)<> Length(FieldDefs) then
     raise EMemDBAPIException.Create(S_API_SEARCH_REQURES_CORRECT_FIELD_COUNT);
   //More detailed check of field format later on.
@@ -1641,10 +1617,11 @@ begin
     IntToStr(FieldDefs[i].FieldIndex) + ' FieldAbsIdx: ' + IntToStr(FieldAbsIdxs[i]));
   end;
 {$ENDIF}
-  result := TidLocal.UserFindRowByIndexRoot(Idx, FieldDefs, FieldAbsIdxs, IRoot, DataRecs);
+  result := TidLocalHint.UserFindRowByIndexRoot(Idx, FieldDefs, FieldAbsIdxs, IRoot, DataRecs);
 end;
 
 function TMemDBTable.API_DataFindEdgeByIndex(T: TObject;
+                                             TidLocalHint: TTidLocal;
                                              IdxName: string;
                                              const DataRecs: TMemDbFieldDataRecs;
                                              Pos: TMemAPIPosition): TMemDBCursor;
@@ -1653,7 +1630,6 @@ var
   IRootGeneric: TMemDbIndexGeneric;
   Tr: TMemDBTransaction;
   Idx: TMemIndexDef;
-  TidLocal: TTidLocal;
   IndexFieldDefs: TMemFieldDefs;
   AllFieldDefs: TMemStreamableList;
   FieldAbsIdxs: TFieldOffsets;
@@ -1667,8 +1643,9 @@ begin
   if Length(IdxName) = 0 then
     raise EMemDBAPIException.Create(S_API_SEARCH_REQUIRES_INDEX);
   Tr := T as TMemDBTransaction;
+  Assert(Tr.Tid = TidLocalHint.Tid);
 
-  IRootGeneric := GetUserTidLocalIndexRoot(Tr.Tid, TidLocal, Idx, IdxName);
+  IRootGeneric := GetUserTidLocalIndexRoot(TidLocalHint, Idx, IdxName);
   if not Assigned(IRootGeneric) then
     raise EMemDBAPIException.Create(S_API_SEARCH_REQUIRES_INDEX);
 
@@ -1679,8 +1656,8 @@ begin
 
   if not (Pos in [ptFirst, ptLast]) then
     raise EMemDBAPIException.Create(S_API_FIND_EDGE_FIRST_OR_LAST);
-  META_CurIndexDefToFieldDefs(Tr.Tid, Idx, IndexFieldDefs, FieldAbsIdxs);
-  AllFieldDefs := META_CurFieldDefList(Tr.Tid);
+  TidLocalHint.META_CurIndexDefToFieldDefs(Idx, IndexFieldDefs, FieldAbsIdxs);
+  AllFieldDefs := TidLocalHint.META_CurFieldDefList;
 
   if Length(DataRecs) <> Length(IndexFieldDefs) then
     raise EMemDBAPIException.Create(S_API_SEARCH_REQURES_CORRECT_FIELD_COUNT);
@@ -1693,7 +1670,7 @@ begin
       IntToStr(FieldDefs[i].FieldIndex) + ' FieldAbsIdx: ' + IntToStr(FieldAbsIdxs[i]));
   end;
 {$ENDIF}
-  Cur := TidLocal.UserFindRowByIndexRoot(Idx, IndexFieldDefs, FieldAbsIdxs, IRoot, DataRecs);
+  Cur := TidLocalHint.UserFindRowByIndexRoot(Idx, IndexFieldDefs, FieldAbsIdxs, IRoot, DataRecs);
   Next := nil;
   result := nil;
   try
@@ -1729,7 +1706,7 @@ begin
           Next := nil;
         end;
 
-        Next := TidLocal.UserMoveToRowByIndexRoot(IRoot, Cur, Pos);
+        Next := TidLocalHint.UserMoveToRowByIndexRoot(IRoot, Cur, Pos);
         if Assigned(Next) then
         begin
 {$IFDEF DEBUG_DATABASE_NAVIGATE}
@@ -1787,6 +1764,7 @@ begin
 end;
 
 procedure TMemDBTable.API_DataReadRow(T:TObject;
+                         TidLocalHint: TTidLocal;
                          Cursor: TMemDBCursor;
                          FieldList: TMemStreamableList);
 var
@@ -1796,10 +1774,11 @@ var
   bufSel: TABSelType;
 begin
   Tr := T as TMemDBTransaction;
+  Assert(Tr.Tid = TidLocalHint.Tid);
   if not (Assigned(Cursor) and Assigned(FieldList)) then
     raise EMemDBInternalException.Create(S_API_INTERNAL_READING_ROW);
   FieldList.ReleaseAndClear;
-  AllFieldDefs := META_CurFieldDefList(TR.Tid);
+  AllFieldDefs := TidLocalHint.META_CurFieldDefList;
 
   if not Cursor.Row.CheckFormatAgainstMetaDefs(Tr.Tid, abLatest, AllFieldDefs, pinEvolve) then
     raise EMemDBConcurrencyException.Create(S_TABLE_FORMAT_CONCURRENTLY_CHANGED_3);
@@ -1811,6 +1790,7 @@ end;
 
 
 procedure TMemDBTable.API_DataInitRowForAppend(T: TObject;
+                                  TidLocalHint: TTidLocal;
                                   Cursor: TMemDBCursor;
                                   FieldList: TMemStreamableList);
 var
@@ -1819,11 +1799,10 @@ var
   MData: TMemFieldData;
   Idx: Integer;
   Tr: TMemDBTransaction;
-  TidLocal: TTidLocal;
 begin
   Tr := T as TMemDbTransaction;
-  TidLocal := GetTidLocal(Tr.Tid);
-  if TidLocal.LayoutChangeRequired then
+  Assert(Tr.Tid = TidLocalHint.Tid);
+  if TidLocalHint.LayoutChangeRequired then
     raise EMemDBAPIException.Create(S_FIELD_LAYOUT_CHANGED);
 
   //Create field list here based on existing metadata.
@@ -1832,7 +1811,7 @@ begin
 
   FieldList.ReleaseAndClear;
 
-  AllFieldDefs := META_CurFieldDefList(Tr.Tid);
+  AllFieldDefs := TidLocalHint.META_CurFieldDefList;
   if AllFieldDefs.Count = 0 then
     raise EMemDBAPIException.Create(S_API_NO_FIELDS_IN_TABLE_AT_APPEND_TIME);
 
@@ -1848,6 +1827,7 @@ end;
 
 
 function TMemDBTable.API_DataRowModOrAppend(T: TObject;
+                                TidLocalHint: TTidLocal;
                                 Cursor: TMemDBCursor;
                                 FieldList: TMemStreamableList): TMemDBCursor;
 var
@@ -1856,17 +1836,16 @@ var
   MData: TMemFieldData;
   Idx: Integer;
   Tr: TMemDBTransaction;
-  TidLocal: TTidLocal;
 begin
   Tr := T as TMemDBTransaction;
-  TidLocal := GetTidLocal(Tr.Tid);
-  if TidLocal.LayoutChangeRequired then
+  Assert(Tr.Tid = TidLocalHint.Tid);
+  if TidLocalHint.LayoutChangeRequired then
     raise EMemDBAPIException.Create(S_FIELD_LAYOUT_CHANGED);
 
   //We will validate new data format here, against existing metadata.
   if not Assigned(FieldList) then
     raise EMemDBInternalException.Create(S_API_INTERNAL_CHANGING_ROW);
-  AllFieldDefs := META_CurFieldDefList(Tr.Tid);
+  AllFieldDefs := TidLocalHint.META_CurFieldDefList;
   if FieldList.Count <> AllFieldDefs.Count then
     raise EMemDBInternalException.Create(S_API_ROW_BAD_STRUCTURE);
   for Idx := 0 to Pred(AllFieldDefs.Count) do
@@ -1880,40 +1859,40 @@ begin
   //either a) CheckChangedRowStructure will barf, or
   // b) Write-after-write conflict detection will catch the error.
   // We'll check it against the Cur metadata in the TidLocal row write.
-  result := TidLocal.UserWriteRowData(Cursor, FieldList);
+  result := TidLocalHint.UserWriteRowData(Cursor, FieldList);
 end;
 
 function TMemDBTable.API_DataRowDelete(T: TObject;
+                                        TidLocalHint: TTidLocal;
                                         Cursor: TMemDBCursor;
                                         AutoInc: boolean): TMemDBCursor;
 var
   Tr: TMemDBTransaction;
-  TidLocal: TTidLocal;
 begin
   Tr := T as TMemDBTransaction;
-  TidLocal := GetTidLocal(Tr.Tid);
-  if TidLocal.LayoutChangeRequired then
+  Assert(Tr.Tid = TidLocalHint.Tid);
+  if TidLocalHint.LayoutChangeRequired then
     raise EMemDBAPIException.Create(S_FIELD_LAYOUT_CHANGED);
   if not Assigned(Cursor) then
     raise EMemDBAPIException.Create(S_API_NO_ROW_FOR_DELETE);
 {$IFDEF DEBUG_DATABASE_NAVIGATE}
   GLogLog(SV_INFO, 'API_DataRowDelete: Actual deletion.');
 {$ENDIF}
-  result := TidLocal.UserDeleteRow(Cursor, AutoInc);
+  result := TidLocalHint.UserDeleteRow(Cursor, AutoInc);
 end;
 
 function TMemDBTable.API_DataGetFieldAbsIdx(T: TObject;
+                                            TidLocalHint: TTidLocal;
                                             FieldName: string): integer;
 var
   FDef: TMemFieldDef;
   Tr: TMemDBTransaction;
-  BufSel: TBufSelector;
 begin
   //Always look in current metadata copy: Field layout doesn't change until
   //the next commit.
   Tr := T as TMemDBTransaction;
-  BufSel := MakeCurrentBufSelector(Tr.Tid);
-  FDef := META_FieldByName(BufSel, FieldName, result);
+  Assert(Tr.Tid = TidLocalHint.Tid);
+  FDef := TidLocalHint.META_FieldByName(abCurrent, FieldName, result, PinEvolve);
   if not Assigned(FDef) then
     raise EMemDBAPIException.Create(S_API_FIELD_NAME_NOT_FOUND);
 end;
@@ -1953,7 +1932,7 @@ begin
       if not (Assigned(Entity) and (Entity is TMemDBTablePersistent)) then
         raise EMemDBAPIException.Create(S_API_ENTITY_NAME_NOT_FOUND);
       Table := Entity as TMemDBTablePersistent;
-      result := Table.META_IndexByName(SelLatest, IndexName, tmpIdx);
+      result := Table.IndexByName(SelLatest, IndexName, tmpIdx, PinEvolve);
       if not Assigned(result) then
         raise EMemDBAPIException.Create(S_API_INDEX_NAME_NOT_FOUND);
     finally

--- a/Common/MemDB2/MemDB2BufBase.pas
+++ b/Common/MemDB2/MemDB2BufBase.pas
@@ -336,6 +336,9 @@ type
 
     function HoldIndexPinInLock(Pin: PMemDbIndexPin): PMemDBIndexPin;
     procedure ReleaseIndexPinOutsideLock(Pin: PMemDbIndexPin; NodeCacheHint: TMemDBNodeCache);
+
+    procedure InvalidateCachedCur(const Tid: TTransactionId); virtual;
+    procedure InvalidateCachedNxtTid(const Tid: TTransactionId); virtual;
   public
     //Determining changes for Tid's is easy to do for composite objects,
     //if you don't mind accruing pins along the way (internal structure).
@@ -1026,6 +1029,7 @@ begin
   finally
     UnlockSelf;
   end;
+  InvalidateCachedNxtTid(Tid);
   CPTidHandle(TidUp);
   DCPLazyHandle(RefUp);
 end;
@@ -1101,6 +1105,7 @@ begin
   finally
     UnlockSelf;
   end;
+  InvalidateCachedNxtTid(Tid);
   CPTidHandle(TidUp);
   DCPLazyHandle(RefUp);
 end;
@@ -1159,6 +1164,7 @@ begin
   finally
     UnlockSelf;
   end;
+  InvalidateCachedNxtTid(Tid);
   CPTidHandle(TidUp);
   DCPLazyHandle(RefUp);
 end;
@@ -1183,6 +1189,8 @@ begin
   finally
     UnlockSelf;
   end;
+  //Just for safety, invalidate any cached copies.
+  InvalidateCachedCur(Tid);
 end;
 
 procedure TMemDBMultiBuffered.PreCommit(const TId: TTransactionId; Phase: TMemDBPreCommitPhase; Opts:TOptimizeSet; Ctxt: TTXLocalContext);
@@ -1291,6 +1299,8 @@ begin
   finally
     UnlockSelf;
   end;
+  InvalidateCachedCur(Tid);
+  InvalidateCachedNxtTid(Tid);
   CPTidHandle(TidUp);
   DCPLazyHandle(RefUp);
 end;
@@ -1335,6 +1345,8 @@ begin
   finally
     UnlockSelf;
   end;
+  InvalidateCachedCur(Tid);
+  InvalidateCachedNxtTid(Tid);
   CPTidHandle(TidUp);
   DCPLazyHandle(RefUp);
 end;
@@ -1400,8 +1412,10 @@ var
   CurPin: PMemDBPinnedItem;
   Item: TMemDBStreamable;
   Nxt, Cur: PMemDbMultiItem;
+  InvalidateCur: boolean;
 begin
   result := false;
+  InvalidateCur := false;
   LockSelf;
   try
     DCPPre(RefUp);
@@ -1457,7 +1471,10 @@ begin
       if Assigned(CurPin) then
         Item := ReUseCurrentPinForINode(Tid, CurPin, IPin, Reason)
       else
+      begin
+        InvalidateCur := true;
         Item := NewCurrentPinFromINode(Tid, IPin, Reason);
+      end;
     end;
     result := Assigned(Item);
     DCPPost(RefUp);
@@ -1465,6 +1482,8 @@ begin
   finally
     UnlockSelf;
   end;
+  if InvalidateCur then
+    InvalidateCachedCur(Tid);
   CPTidHandle(TidUp);
   DCPLazyHandle(RefUp);
 end;
@@ -1726,8 +1745,9 @@ var
   Pin: PMemDBPinnedItem;
   RefUp: TReferenceUpdate;
   TidUp: TTidUpdate;
-
+  InvalidateCur: boolean;
 begin
+  InvalidateCur := false;
   LockSelf;
   try
     DCPPre(RefUp);
@@ -1739,13 +1759,18 @@ begin
     if Assigned(Pin) then
       result := ReUseCurrentPinInternal(Pin, Reason)
     else
+    begin
+      InvalidateCur := true;
       result := NewCurrentPinInternal(Tid, Reason);
+    end;
 
     DCPPost(RefUp);
     CPTidPost(Tid, TidUp);
   finally
     UnlockSelf;
   end;
+  if InvalidateCur then
+    InvalidateCachedCur(Tid);
   CPTidHandle(TidUp);
   DCPLazyHandle(RefUp);
 end;
@@ -1788,8 +1813,9 @@ var
   Pin: PMemDbPinnedItem;
   RefUp: TReferenceUpdate;
   TidUp: TTidUpdate;
-
+  InvalidateCur: boolean;
 begin
+  InvalidateCur := false;
   LockSelf;
   try
     DCPPre(RefUp);
@@ -1812,7 +1838,10 @@ begin
       if Assigned(Pin) then
         result := ReUseCurrentPinInternal(Pin, Reason)
       else
+      begin
+        InvalidateCur := true;
         result := NewCurrentPinInternal(Tid, Reason);
+      end;
       BufSelected := abCurrent;
     end;
     DCPPost(RefUp);
@@ -1820,6 +1849,8 @@ begin
   finally
     UnlockSelf;
   end;
+  if InvalidateCur then
+    InvalidateCachedCur(Tid);
   CPTidHandle(TidUp);
   DCPLazyHandle(RefUp);
 end;
@@ -2035,6 +2066,16 @@ begin
     raise EMemDBException.Create(S_JOURNAL_REPLAY_CHANGETYPE_DISAGREES);
   end;
   ExpectTag(Stream, mstDblBufferedEnd);
+end;
+
+procedure TMemDbMultiBuffered.InvalidateCachedCur(const Tid: TTransactionId);
+begin
+  //NOP.
+end;
+
+procedure TMemDbMultiBuffered.InvalidateCachedNxtTid(const Tid: TTransactionId);
+begin
+  //NOP.
 end;
 
 {  TMemDBMultiBufferedTiny }

--- a/Common/MemDB2/MemDB2Buffered.pas
+++ b/Common/MemDB2/MemDB2Buffered.pas
@@ -104,7 +104,11 @@ type
   TMemDbRowProxy = class(TReffedProxy)
   end;
 
+{$IFDEF USE_STRIPED_LOCK}
   TMemDBRow = class(TMemDbMultiBufferedStriped)
+{$ELSE}
+  TMemDBRow = class(TMemDBMultiBufferedTiny)
+{$ENDIF}
   private
     FRowID: TGUID;
     FTable: TMemDBTablePersistent;
@@ -166,10 +170,8 @@ type
     //A/B buffer holds TMemTableMetadataItem
     procedure CheckABListChanges(const Tid: TTransactionId);
   protected
-    //TODO - Recheck callers of these have TidLocal or use META_ functions.
-    function FieldsByNames(const AB: TBufSelector; const Names: TMDBFieldNames; var AbsIdxs: TFieldOffsets; Reason: TPinReason): TMemFieldDefs;
-    function FieldByName(const AB: TBufSelector; const Name: string; var AbsIndex: integer; Reason: TPinReason): TMemFieldDef;
-    function IndexByName(const AB: TBufSelector; const Name: string; var AbsIndex: integer; Reason: TPinReason): TMemIndexDef;
+    procedure InvalidateCachedCur(const Tid: TTransactionId); override;
+    procedure InvalidateCachedNxtTid(const Tid: TTransactionId); override;
   public
     procedure PreCommit(const TId: TTransactionId; Phase: TMemDBPreCommitPhase; Opts:TOptimizeSet; Ctxt: TTXLocalContext); override;
     procedure Init(const Tid: TTransactionId; Parent: TObject; Name:string; DSName: boolean); override;
@@ -213,17 +215,9 @@ type
     procedure HandleReleaseForAPI(Sender: TObject);
     procedure MetadataDCPHandle(Sender: TObject; const Update:TReferenceUpdate);
 
-    property Metadata: TMemDBEntityMetadata read FMetadata;
   public
     constructor Create;
     destructor Destroy; override;
-
-    function META_PinCurrent(const Tid: TTransactionId; Reason: TPinReason): TMemDBStreamable; virtual;
-    function META_GetNext(const Tid: TTransactionId): TMemDBStreamable; virtual;
-    function META_GetPinLatest(const Tid: TTransactionId;
-                            var BufSelected: TAbSelType; Reason: TPinReason): TMemDBStreamable; virtual;
-    procedure META_RequestChange(const Tid: TTransactionId); virtual;
-    procedure META_Delete(const Tid: TTransactionId); virtual;
 
     procedure SizeHint(const Tid: TTransactionId; var SizeHint: TDBSizeHint); virtual;
     procedure StartTransaction(const Tid: TTransactionId; Ctxt: TTXLocalContext); virtual;
@@ -237,6 +231,7 @@ type
     property ParentDB: TMemDBDatabasePersistent read FParentDB;
     property Proxy: TMemDBEntityProxy read FProxy;
     property Interfaced: TMemDBAPIInterfacedObject read FInterfaced;
+    property Metadata: TMemDBEntityMetadata read FMetadata;
   end;
 
   //TODO - Re-check this, I think it's OK,
@@ -398,6 +393,14 @@ type
     FInternalIndexChangeset: TIndexChangeset;
 
     FCPRows: TIndexedStoreO; //Rows changed or pinned by cur Txion.
+
+    //Cached metadata.
+    FCachedCur: TMemDbStreamable;
+    FCachedNxt: TMemDbStreamable;
+    FCachedCurValid, FCachedNxtValid: boolean;
+    //Re-entrancy check. A pin or mod by *anyone else* clears our caches.
+    FCacheReenter: boolean;
+
     function LookaheadHelper(Stream: TStream; Scratch: boolean; var Created: boolean): TMemDBRow;
 
     procedure CheckTableRowCount;
@@ -467,9 +470,27 @@ type
     function UserDeleteRow(Cursor: TMemDbCursor; AutoInc: boolean): TMemDBCursor;
     function UserWriteRowData(Cursor:TMemDbCursor; FieldList: TMemStreamableList): TMemDBCursor;
 
+    //Cached metadata functions.
+    //These ONLY to be invoked single-threadedly by User API code, not internal handling.
+    procedure META_CurIndexDefToFieldDefs(IndexDef: TMemIndexDef; var FieldDefs: TMemFieldDefs; var FieldAbsIdxs: TFieldOffsets);
+    function META_CurFieldDefList: TMemStreamableList;
+    function META_FieldsByNames(selType: TABSelType; const Names: TMDBFieldNames; var AbsIdxs: TFieldOffsets; PinReason: TPinReason): TMemFieldDefs;
+    function META_FieldByName(selType: TABSelType; const Name: string; var AbsIndex: integer; PinReason: TPinReason): TMemFieldDef;
+    function META_IndexByName(selType: TABSelType; const Name: string; var AbsIndex: integer; PinReason: TPinReason): TMemIndexDef;
+
+    procedure InvalidateCachedCur;
+    procedure InvalidateCachedNxtTid;
+    //Cached metadata functions.
+    //These ONLY to be invoked single-threadedly by User API code, not internal handling.
+    function META_PinCurrent(Reason: TPinReason): TMemDBStreamable;
+    function META_GetNext: TMemDBStreamable;
+    function META_GetPinLatest(var BufSelected: TAbSelType;
+                               Reason: TPinReason): TMemDBStreamable;
+
     property DataChanged: boolean read FDataChanged;
     property DataChangePrePrepare: boolean read FDataChangePrePrepare write FDataChangePrePrepare;
     property LayoutChangeRequired: boolean read FLayoutChangeRequired;
+    property Tid: TTransactionId read FTid;
   end;
 
   TRowIndexNode = class(TIndexNode)
@@ -556,7 +577,6 @@ type
     procedure HandleAddRefForData(Sender: TObject);
     procedure HandleReleaseForData(Sender: TObject);
 
-    function GetOptTidLocal(const Tid: TTransactionId): TTidLocal;
     function GetTidLocal(const Tid: TTransactionId): TTidLocal;
 
     function GetMakeListHelpers(const Tid: TTransactionId;
@@ -576,7 +596,12 @@ type
     procedure LookaheadHelper(Stream: TStream;
                               var MetadataInStream: boolean;
                               var DataInStream: boolean);
+
+    procedure InvalidateCachedCur(const Tid: TTransactionId);
+    procedure InvalidateCachedNxtTid(const Tid: TTransactionId);
   public
+    function GetOptTidLocal(const Tid: TTransactionId): TTidLocal;
+
     constructor Create;
     destructor Destroy; override;
 
@@ -598,18 +623,12 @@ type
     function AnyChanges(const Tid:TTransactionId; Ctxt: TTXLocalContext): boolean; override;
     function AnyChangesForTid(const Tid: TTransactionId; Ctxt: TTXLocalContext): boolean; override;
 
-    //TODO - Cache metadata for current access for API to reduce lock contention.
-    function META_PinCurrent(const Tid: TTransactionId; Reason: TPinReason): TMemDBStreamable; override;
-    function META_GetPinLatest(const Tid: TTransactionId;
-                            var BufSelected: TAbSelType; Reason: TPinReason): TMemDBStreamable; override;
-    procedure META_RequestChange(const Tid: TTransactionId); override;
-    procedure META_Delete(const Tid: TTransactionId); override;
-                            
-    function META_FieldsByNames(const AB: TBufSelector; const Names: TMDBFieldNames; var AbsIdxs: TFieldOffsets): TMemFieldDefs;
-    function META_FieldByName(const AB: TBufSelector; const Name: string; var AbsIndex: integer): TMemFieldDef;
-    function META_IndexByName(const AB: TBufSelector; const Name: string; var AbsIndex: integer): TMemIndexDef;
+    //Non-cached metadata access.
+    function FieldsByNames(const AB: TBufSelector; const Names: TMDBFieldNames; var AbsIdxs: TFieldOffsets; PinReason: TPinReason): TMemFieldDefs;
+    function FieldByName(const AB: TBufSelector; const Name: string; var AbsIndex: integer; PinReason: TPinReason): TMemFieldDef;
+    function IndexByName(const AB: TBufSelector; const Name: string; var AbsIndex: integer; PinReason: TPinReason): TMemIndexDef;
 
-    function GetUserTidLocalIndexRoot(const Tid: TTransactionId; var TidLocal: TTidLocal; var Idx: TMemIndexDef; IdxName: string): TMemDBIndexGeneric;
+    function GetUserTidLocalIndexRoot(TidLocal: TTidLocal; var Idx: TMemIndexDef; IdxName: string): TMemDBIndexGeneric;
   end;
 
   TMemDBEntityChangeType = (
@@ -1026,6 +1045,7 @@ const
   S_FKEYS_INTERNAL_39 = 'Foreign key checking internal error 39.';
   S_FKEYS_INTERNAL_40 = 'Foreign key checking internal error 40.';
   S_ENTITY_LIST_CONFUSION_CHECKING_CHANGES = 'Error: did not expect async mod of entity lists at this time.';
+  S_API_TABLE_METADATA_NOT_COMMITED = 'No committed metadata for this table (api level)';
 
 { Misc Functions }
 
@@ -1520,39 +1540,245 @@ begin
   FMetadata.Init(Tid, self, Name, DSName);
 end;
 
-function TMemDBEntity.META_PinCurrent(const Tid: TTransactionId; Reason: TPinReason): TMemDBStreamable;
-begin
-  result := FMetadata.PinCurrent(Tid, Reason);
-end;
-
-function TMemDBEntity.META_GetNext(const Tid: TTransactionId): TMemDBStreamable;
-begin
-  result := FMetadata.GetNext(Tid);
-end;
-
-function TMemDBEntity.META_GetPinLatest(const Tid: TTransactionId;
-                        var BufSelected: TAbSelType; Reason: TPinReason): TMemDBStreamable;
-begin
-  result := FMetadata.GetPinLatest(Tid, BufSelected, Reason);
-end;
-
-procedure TMemDBEntity.META_RequestChange(const Tid: TTransactionId);
-begin
-  FMetadata.RequestChange(Tid, ilReadRepeatable);
-end;
-
-procedure TMemDbEntity.META_Delete(const Tid: TTransactionId);
-begin
-  FMetadata.Delete(Tid, ilReadRepeatable);
-end;
-
 { TTidLocal }
+
+function TTidLocal.META_FieldByName(selType: TABSelType; const Name: string; var AbsIndex: integer; PinReason: TPinReason): TMemFieldDef;
+var
+  MC: TMemDbStreamable;
+  bufSel: TABSelType;
+begin
+  MC := nil;
+  case selType of
+    abCurrent: MC := self.META_PinCurrent(PinReason);
+    abNext: MC := self.META_GetNext;
+    abLatest: MC := self.META_GetPinLatest(bufSel, PinReason);
+  else
+    Assert(false);
+  end;
+  if AssignedNotSentinel(MC) then
+    result := FieldByNameInt(MC as TMemTableMetadataItem, Name, AbsIndex)
+  else
+    result := nil;
+end;
+
+function TTidLocal.META_FieldsByNames(selType: TABSelType; const Names: TMDBFieldNames; var AbsIdxs: TFieldOffsets; PinReason: TPinReason): TMemFieldDefs;
+var
+  MC: TMemDbStreamable;
+  bufSel: TABSelType;
+begin
+  MC := nil;
+  case selType of
+    abCurrent: MC := self.META_PinCurrent(PinReason);
+    abNext: MC := self.META_GetNext;
+    abLatest: MC := self.META_GetPinLatest(bufSel, PinReason);
+  else
+    Assert(false);
+  end;
+  if AssignedNotSentinel(MC) then
+    result := FieldsByNamesInt(MC as TMemTableMetadataItem, Names, AbsIdxs)
+  else
+  begin
+    SetLength(result, 0);
+    SetLength(AbsIdxs, 0);
+  end;
+end;
+
+function TTidLocal.META_IndexByName(selType: TABSelType; const Name: string; var AbsIndex: integer; PinReason: TPinReason): TMemIndexDef;
+var
+  MC: TMemDbStreamable;
+  bufSel: TABSelType;
+begin
+  MC := nil;
+  case selType of
+    abCurrent: MC := self.META_PinCurrent(PinReason);
+    abNext: MC := self.META_GetNext;
+    abLatest: MC := self.META_GetPinLatest(bufSel, PinReason);
+  else
+    Assert(false);
+  end;
+  if AssignedNotSentinel(MC) then
+    result := IndexByNameInt(MC as TMemTableMetadataItem, Name, AbsIndex)
+  else
+    result := nil;
+end;
+
+procedure TTidLocal.META_CurIndexDefToFieldDefs(IndexDef: TMemIndexDef; var FieldDefs: TMemFieldDefs; var FieldAbsIdxs: TFieldOffsets);
+begin
+  Assert(Assigned(IndexDef));
+  Assert(IndexDef.FieldNameCount > 0);
+  FieldDefs := META_FieldsByNames(abLatest, IndexDef.FieldArray, FieldAbsIdxs, PinEvolve);
+end;
+
+function TTidLocal.META_CurFieldDefList: TMemStreamableList;
+var
+  CB: TMemDBStreamable;
+  CurMetadata: TMemTableMetadataItem;
+begin
+  CB := META_PinCurrent(pinEvolve);
+  if NotAssignedOrSentinel(CB) then
+    raise EMemDBAPIException.Create(S_API_TABLE_METADATA_NOT_COMMITED);
+  CurMetadata := CB as TMemTableMetadataItem;
+  result := CurMetadata.FieldDefs;
+end;
+
+procedure TTidLocal.InvalidateCachedCur;
+begin
+  if not FCacheReenter then
+  begin
+    FCachedCur.Release;
+    FCachedCur := nil;
+    FCachedCurValid := false;
+  end;
+  inherited;
+end;
+
+procedure TTidLocal.InvalidateCachedNxtTid;
+begin
+  if not FCacheReenter then
+  begin
+    FCachedNxt.Release;
+    FCachedNxt := nil;
+    FCachedNxtValid := false;
+  end;
+  inherited;
+end;
+
+//Caching here to enable user and other API functions to avoid taking spinlocks
+//multiple times for each row processed.
+
+function TTidLocal.META_PinCurrent(Reason: TPinReason): TMemDBStreamable;
+begin
+  FCacheReenter := true;
+  try
+    if FCachedCurValid and (Reason <> PinFinalCheck) then
+    begin
+      result := FCachedCur;
+{$IFDEF CHECK_META_CACHING}
+      Assert(result = FParentTable.FMetadata.PinCurrent(self.FTid, Reason));
+{$ENDIF}
+    end
+    else
+    begin
+      result := FParentTable.FMetadata.PinCurrent(self.FTid, Reason);
+      FCachedCur.Release;
+{$IFDEF CHECK_META_CACHING}
+      FCachedCur := result.AddRef as TMemDBStreamable;
+{$ELSE}
+      FCachedCur := result.DeepClone(result) as TMemDBStreamable;
+{$ENDIF}
+      FCachedCurValid := true;
+    end;
+  finally
+    FCacheReenter := false;
+  end;
+end;
+
+function TTidLocal.META_GetNext: TMemDBStreamable;
+begin
+  FCacheReenter := true;
+  try
+    if FCachedNxtValid then
+    begin
+      result := FCachedNxt;
+{$IFDEF CHECK_META_CACHING}
+      Assert(result = FParentTable.FMetadata.GetNext(self.FTid));
+{$ENDIF}
+    end
+    else
+    begin
+      result := FParentTable.FMetadata.GetNext(self.FTid);
+      FCachedNxt.Release;
+{$IFDEF CHECK_META_CACHING}
+      FCachedNxt := result.AddRef as TMemDBStreamable;
+{$ELSE}
+      FCachedNxt := result.DeepClone(result) as TMemDBStreamable;
+{$ENDIF}
+      FCachedNxtValid := true;
+    end;
+  finally
+    FCacheReenter := false;
+  end;
+end;
+
+function TTidLocal.META_GetPinLatest(var BufSelected: TAbSelType;
+                           Reason: TPinReason): TMemDBStreamable;
+var
+  LBufSel:TAbSelType;
+begin
+  FCacheReenter := true;
+  try
+    if FCachedCurValid and FCachedNxtValid and (Reason <> PinFinalCheck) then
+    begin
+      //Not going to try to do clever stuff when only one of the flags is valid.
+      if Assigned(FCachedNxt) then
+      begin
+        result := FCachedNxt;
+        LBufSel := abNext;
+      end
+      else
+      begin
+        result := FCachedCur;
+        LBufSel := abCurrent;
+      end;
+{$IFDEF CHECK_META_CACHING}
+      Assert(result = FParentTable.FMetadata.GetPinLatest(Self.FTid, BufSelected, Reason));
+      Assert(BufSelected = LBufSel);
+{$ENDIF}
+      BufSelected := LBufSel;
+    end
+    else
+    begin
+      result := FParentTable.FMetadata.GetPinLatest(Self.FTid, BufSelected, Reason);
+      case BufSelected of
+        abCurrent: begin
+          if FCachedCurValid then
+          begin
+{$IFDEF CHECK_META_CACHING}
+            Assert(result = FCachedCur)
+{$ENDIF}
+          end
+          else
+          begin
+            FCachedCur.Release;
+{$IFDEF CHECK_META_CACHING}
+            FCachedCur := result.AddRef as TMemDBStreamable;
+{$ELSE}
+            FCachedCur := result.DeepClone(result) as TMemDBStreamable;
+{$ENDIF}
+            FCachedCurValid := true;
+          end;
+        end;
+        abNext: begin
+          if FCachedNxtValid then
+          begin
+{$IFDEF CHECK_META_CACHING}
+            Assert(result = FCachedNxt)
+{$ENDIF}
+          end
+          else
+          begin
+            FCachedNxt.Release;
+{$IFDEF CHECK_META_CACHING}
+            FCachedNxt := result.AddRef as TMemDBStreamable;
+{$ELSE}
+            FCachedNxt := result.DeepClone(result) as TMemDBStreamable;
+{$ENDIF}
+            FCachedNxtValid := true;
+          end;
+        end;
+        abLatest: Assert(false);
+      end;
+    end;
+  finally
+    FCacheReEnter := false;
+  end;
+end;
 
 procedure TTidLocal.HandleHelperChangeRequest(Sender: TObject);
 begin
   FParentTable.FMetadata.RequestChange(FTid, ilReadRepeatable);
   UpdateNHelpers;
-  //TODO - Clear cached copies, if they're here.
+  //Cache clearing done by metadata override func.
 end;
 
 procedure TTidLocal.UpdateLayout(PinReason: TPinReason);
@@ -1866,10 +2092,8 @@ begin
           //Check indexes reference same underlying field:
           //Same abs position in array for field index,
           //and also, field number change is same for field, and index.
-          FieldDefs1 := (FParentTable.FMetadata as TMemDBTableMetadata)
-            .FieldsByNames(selNext, IndexDef1.FieldArray, AbsIndexes1, PinReason);
-          FieldDefs2 := (FParentTable.FMetadata as TMemDBTableMetadata)
-            .FieldsByNames(selCurrent, IndexDef2.FieldArray, AbsIndexes2, PinReason);
+          FieldDefs1 := FParentTable.FieldsByNames(selNext, IndexDef1.FieldArray, AbsIndexes1, PinReason);
+          FieldDefs2 := FParentTable.FieldsByNames(selCurrent, IndexDef2.FieldArray, AbsIndexes2, PinReason);
 
           if not ((Length(FieldDefs1) > 0) // i < NCIndexCount
             and (Length(FieldDefs2) > 0) // i < CCIndexCount
@@ -1903,8 +2127,7 @@ begin
         end
         else
         begin
-          FieldDefs1 := (FParentTable.FMetadata as TMemDBTableMetadata)
-            .FieldsByNames(selNext, IndexDef1.FieldArray, AbsIndexes1, PinReason);
+          FieldDefs1 := FParentTable.FieldsByNames(selNext, IndexDef1.FieldArray, AbsIndexes1, PinReason);
 
           if not ((Length(FieldDefs1) > 0) // i < NCIndexCount
             and (Length(FieldDefs1) = Length(AbsIndexes1))) then
@@ -2131,6 +2354,13 @@ begin
       FParentTable.HandleReleaseForTidLocal(self);
   end;
 
+  FCachedCur.Release;
+  FCachedNxt.Release;
+  FCachedCur := nil;
+  FCachedNxt := nil;
+  FCachedCurValid := false;
+  FCachedNxtValid := false;
+
   FIndexHelper.Free;
   FFieldHelper.Free;
   FEmptyList.Release;
@@ -2337,7 +2567,7 @@ var
   RowCur, RowNext: TMemDBStreamable;
   Added, Changed, Deleted, Null:boolean;
 begin
-  LM := FParentTable.Metadata.GetPinLatest(FTid, BufSel, pinFinalCheck);
+  LM := FParentTable.Metadata.GetPinLatest(Tid, BufSel, pinFinalCheck);
   FieldsNull := NotAssignedOrSentinel(LM);
   if not FieldsNull then
   begin
@@ -2467,11 +2697,11 @@ begin
     NextBufSelector := MakeNextBufSelector(FTid);
 
     //Only get next metadata copy here, because del table -> No NC.
-    NC := FParentTable.Metadata.GetNext(FTid) as TMemTableMetadataItem;
+    NC := FParentTable.Metadata.GetNext(Tid) as TMemTableMetadataItem;
     Assert(Assigned(NC));
 
     IDef := NC.IndexDefs[i] as TMemIndexDef;
-    FieldDefs := (FParentTable.Metadata as TMemDbTableMetadata).FieldsByNames(NextBufSelector,
+    FieldDefs := FParentTable.FieldsByNames(NextBufSelector,
                                                                  IDef.FieldArray,
                                                                  SparseOffsets, pinEvolve); //TODO FinalCheck?
     Assert(Length(FieldDefs) = Length(SparseOffsets));
@@ -2959,8 +3189,7 @@ begin
   CCDef := CC.IndexDefs[i] as TMemIndexDef;
   if CCDef.IndexAttrs * [iaUnique, iaNotEmpty] <> [] then
   begin
-    FieldDefs := (FParentTable.Metadata as TMemDbTableMetadata).
-      FieldsByNames(CurrentBufSelector, CCDef.FieldArray, SparseOffsets, pinFinalCheck);
+    FieldDefs := FParentTable.FieldsByNames(CurrentBufSelector, CCDef.FieldArray, SparseOffsets, pinFinalCheck);
 
     Assert(Length(FieldDefs) = Length(SparseOffsets));
     if not CCDef.FieldNameCount = Length(FieldDefs) then
@@ -3552,14 +3781,12 @@ end;
 
 function TTidLocal.GetUserIndexRoot(var Idx: TMemIndexDef; IdxName: string): TMemDBIndexGeneric;
 var
-  Cur: TBufSelector;
   AbsIndex: integer;
 begin
-  Cur := MakeCurrentBufSelector(FTid);
   //Indexes are consistent with pinned current metadata.
   if Length(IdxName) > 0 then
   begin
-    Idx := (FParentTable.Metadata as TMemDBTableMetadata).IndexByName(Cur, IdxName, AbsIndex, pinEvolve);
+    Idx := META_IndexByName(abCurrent, IdxName, AbsIndex, PinEvolve);
     Assert(AbsIndex >= 0);
     Assert(AbsIndex < FLocalIndexCopies.Count);
     result := FLocalIndexCopies.Items[AbsIndex] as TMemDbIndex;
@@ -3766,7 +3993,7 @@ begin
     begin
       Row := ILeaf.Row as TMemDBRow;
 
-      S := FParentTable.Metadata.PinCurrent(FTid, pinEvolve);
+      S := META_PinCurrent(pinEvolve);
       if NotAssignedOrSentinel(S) then
         raise EMemDBInternalException.Create(S_NAV_TABLE_METADATA_NOT_COMMITED);
       Cur := S as TMemTableMetadataItem;
@@ -3889,7 +4116,8 @@ begin
   Appending := not Assigned(Cursor);
   Assert(Assigned(FieldList));
   //I am in TidLocal, so atomic Meta/Index pin has already happened.
-  CurMeta := FParentTable.META_PinCurrent(FTid, pinEvolve) as TMemTableMetadataItem;
+
+  CurMeta := META_PinCurrent(pinEvolve) as TMemTableMetadataItem;
   TMemDBRow.StaticCheckFormatAgainstMeta(FieldList, CurMeta);
   result := nil;
   if Appending then
@@ -4378,7 +4606,7 @@ begin
     else
     begin
       WrTag(Stream, mstTableUnchangedName);
-      Meta := META_GetPinLatest(Tid, tmpSelected, pinEvolve);
+      Meta := Metadata.GetPinLatest(Tid, tmpSelected, pinEvolve);
       WrStreamString(Stream, (Meta as TMemEntityMetadataItem).EntityName);
     end;
     if TidLocal.DataChangePrePrepare then
@@ -4455,7 +4683,7 @@ begin
   begin
     ExpectTag(Stream, mstTableUnchangedName);
     TblName := RdStreamString(Stream);
-    Cur := META_PinCurrent(PseudoTid, PinEvolve) as TMemTableMetadataItem;
+    Cur := Metadata.PinCurrent(PseudoTid, PinEvolve) as TMemTableMetadataItem;
     if CompareStr(TblName, Cur.EntityName) <> 0 then
       raise EMemDBInternalException.Create(S_JOURNAL_REPLAY_NAMES_INCONSISTENT);
   end;
@@ -4579,8 +4807,8 @@ var
 begin
   inherited;
 
-  Cur := META_PinCurrent(Tid, pinFinalCheck);
-  Next := META_GetNext(Tid);
+  Cur := Metadata.PinCurrent(Tid, pinFinalCheck);
+  Next := Metadata.GetNext(Tid);
   ChangeFlagsFromPinned(Cur, Next, Added, Changed, Deleted, Null);
   if Null then
     exit; //Deleted case, still check all the rows have been deleted.
@@ -4716,7 +4944,7 @@ begin
   IndexHelper := result.FIndexHelper;
 end;
 
-//TODO - Move this into TTidLocal?
+
 procedure TMemDBTablePersistent.GetCurrNxtMetaCopiesEx(const Tid: TTransactionId;
                                            var CC, NC: TMemTableMetadataItem;
                                            var CCFieldCount, CCIndexCount,
@@ -4759,57 +4987,88 @@ begin
   GetCurrNxtMetaCopiesEx(Tid, CC,NC, CCFieldCount, NCFieldCount, CCIndexCount, NCIndexCount, PinReason);
 end;
 
-function TMemDbTablePersistent.META_PinCurrent(const Tid: TTransactionId; Reason: TPinReason): TMemDBStreamable;
+procedure TMemDbTablePersistent.InvalidateCachedCur(const Tid: TTransactionId);
+var
+  TidLocal: TTidLocal;
 begin
-  GetTidLocal(Tid);
-  result := inherited;
+  TidLocal := GetOptTidLocal(Tid);
+  if Assigned(TidLocal) then
+    TidLocal.InvalidateCachedCur;
 end;
 
-function TMemDbTablePersistent.META_GetPinLatest(const Tid: TTransactionId;
-                        var BufSelected: TAbSelType; Reason: TPinReason): TMemDBStreamable;
+procedure TMemDbTablePersistent.InvalidateCachedNxtTid(const Tid: TTransactionId);
+var
+  TidLocal: TTidLocal;
 begin
-  GetTidLocal(Tid);
-  result := inherited;
+  TidLocal := GetOptTidLocal(Tid);
+  if Assigned(TidLocal) then
+    TidLocal.InvalidateCachedNxtTid;
 end;
 
-procedure TMemDbTablePersistent.META_RequestChange(const Tid: TTransactionId);
+function TMemDbTablePersistent.FieldsByNames(const AB: TBufSelector; const Names: TMDBFieldNames; var AbsIdxs: TFieldOffsets; PinReason: TPinReason): TMemFieldDefs;
+var
+  MC: TMemDbStreamable;
+  bufSel: TABSelType;
 begin
-  GetTidLocal(Tid);
-  inherited;
+  MC := nil;
+  case AB.SelType of
+    abCurrent: MC := Metadata.PinCurrent(AB.TId, PinReason);
+    abNext: MC := Metadata.GetNext(AB.TId);
+    abLatest: MC := Metadata.GetPinLatest(AB.TId, bufSel, PinReason);
+  else
+    Assert(false);
+  end;
+  if AssignedNotSentinel(MC) then
+    result := FieldsByNamesInt(MC as TMemTableMetadataItem, Names, AbsIdxs)
+  else
+  begin
+    SetLength(result, 0);
+    SetLength(AbsIdxs, 0);
+  end;
 end;
 
-procedure TMemDbTablePersistent.META_Delete(const Tid: TTransactionId);
+function TMemDbTablePersistent.FieldByName(const AB: TBufSelector; const Name: string; var AbsIndex: integer; PinReason: TPinReason): TMemFieldDef;
+var
+  MC: TMemDbStreamable;
+  bufSel: TABSelType;
 begin
-  GetTidLocal(Tid);
-  inherited;
+  MC := nil;
+  case AB.SelType of
+    abCurrent: MC := Metadata.PinCurrent(AB.TId, PinReason);
+    abNext: MC := Metadata.GetNext(AB.TId);
+    abLatest: MC := Metadata.GetPinLatest(AB.TId, bufSel, PinReason);
+  else
+    Assert(false);
+  end;
+  if AssignedNotSentinel(MC) then
+    result := FieldByNameInt(MC as TMemTableMetadataItem, Name, AbsIndex)
+  else
+    result := nil;
 end;
 
-function TMemDbTablePersistent.META_FieldsByNames(const AB: TBufSelector; const Names: TMDBFieldNames; var AbsIdxs: TFieldOffsets): TMemFieldDefs;
+function TMemDbTablePersistent.IndexByName(const AB: TBufSelector; const Name: string; var AbsIndex: integer; PinReason: TPinReason): TMemIndexDef;
+var
+  MC: TMemDbStreamable;
+  bufSel: TABSelType;
 begin
-  if AB.SelType <> TAbSelType.abNext then
-    GetTidLocal(AB.TId);
-  result := (Metadata as TMemDbTableMetadata).FieldsByNames(AB, Names, AbsIdxs, pinEvolve);
+  MC := nil;
+  case AB.SelType of
+    abCurrent: MC := Metadata.PinCurrent(AB.TId, PinReason);
+    abNext: MC := Metadata.GetNext(AB.TId);
+    abLatest: MC := Metadata.GetPinLatest(AB.TId, bufSel, PinReason);
+  else
+    Assert(false);
+  end;
+  if AssignedNotSentinel(MC) then
+    result := IndexByNameInt(MC as TMemTableMetadataItem, Name, AbsIndex)
+  else
+    result := nil;
 end;
 
-function TMemDbTablePersistent.META_FieldByName(const AB: TBufSelector; const Name: string; var AbsIndex: integer): TMemFieldDef;
+function TMemDbTablePersistent.GetUserTidLocalIndexRoot(TidLocal: TTidLocal; var Idx: TMemIndexDef; IdxName: string): TMemDBIndexGeneric;
 begin
-  if AB.SelType <> TAbSelType.abNext then
-    GetTidLocal(AB.TId);
-  result := (Metadata as TMemDBTableMetadata).FieldByName(AB, Name, AbsIndex, pinEvolve);
-end;
-
-function TMemDbTablePersistent.META_IndexByName(const AB: TBufSelector; const Name: string; var AbsIndex: integer): TMemIndexDef;
-begin
-  if AB.SelType <> TAbSelType.abNext then
-    GetTidLocal(AB.TId);
-  result := (Metadata as TMemDbTableMetadata).IndexByName(AB, Name, AbsIndex, pinEvolve);
-end;
-
-function TMemDbTablePersistent.GetUserTidLocalIndexRoot(const Tid: TTransactionId; var TidLocal: TTidLocal; var Idx: TMemIndexDef; IdxName: string): TMemDBIndexGeneric;
-begin
-  TidLocal := GetTidLocal(Tid);
   result := TidLocal.GetUserIndexRoot(Idx, IdxName);
-  if (Length(IdxName) = 0) and (Tid.Iso < ilSnapshot) then
+  if (Length(IdxName) = 0) and (TidLocal.Tid.Iso < ilSnapshot) then
   begin
     //Belt and braces in case caller tries to use internal index when shouldn't.
     Idx := nil;
@@ -4968,11 +5227,11 @@ begin
     Meta.TableReferring.Metadata.RequireCurrentAtomic(Tid);
 
     M := Meta.TableReferring.Metadata as TMemDBTableMetadata;
-    Meta.IndexDefReferring := M.IndexByName(SelLatest, FKM.IndexReferer, Meta.IndexDefReferringAbsIdx, pinFinalCheck);
+    Meta.IndexDefReferring := Meta.TableReferring.IndexByName(SelLatest, FKM.IndexReferer, Meta.IndexDefReferringAbsIdx, pinFinalCheck);
     if not Assigned(Meta.IndexDefReferring) then
       raise EMemDBException.Create(S_FK_INDEX_NOT_FOUND);
     //..and fields (names should already have been checked, tables before fkeys).
-    Meta.FieldDefsReferring := M.FieldsByNames(SelLatest, Meta.IndexDefReferring.FieldArray, Meta.FieldDefsReferringAbsIdx, pinFinalCheck);
+    Meta.FieldDefsReferring := Meta.TableReferring.FieldsByNames(SelLatest, Meta.IndexDefReferring.FieldArray, Meta.FieldDefsReferringAbsIdx, pinFinalCheck);
     if Length(Meta.FieldDefsReferring) = 0 then
       raise EMemDBInternalException.Create(S_FK_INDEX_FIELD_INTERNAL);
 
@@ -5038,11 +5297,11 @@ begin
     Meta.TableReferred.Metadata.RequireCurrentAtomic(Tid);
 
     M := Meta.TableReferred.Metadata as TMemDBTableMetadata;
-    Meta.IndexDefReferred := M.IndexByName(SelLatest, FKM.IndexReferred, Meta.IndexDefReferredAbsIdx, pinFinalCheck);
+    Meta.IndexDefReferred := Meta.TableReferred.IndexByName(SelLatest, FKM.IndexReferred, Meta.IndexDefReferredAbsIdx, pinFinalCheck);
     if not Assigned(Meta.IndexDefReferred) then
       raise EMemDBException.Create(S_FK_INDEX_NOT_FOUND);
     //...And fields (names should already have been checked, tables before fkeys).
-    Meta.FieldDefsReferred := M.FieldsByNames(SelLatest, Meta.IndexDefReferred.FieldArray, Meta.FieldDefsReferredAbsIdx, pinFinalCheck);
+    Meta.FieldDefsReferred := Meta.TableReferred.FieldsByNames(SelLatest, Meta.IndexDefReferred.FieldArray, Meta.FieldDefsReferredAbsIdx, pinFinalCheck);
     if Length(Meta.FieldDefsReferred) = 0 then
       raise EMemDBInternalException.Create(S_FK_INDEX_FIELD_INTERNAL);
 
@@ -5149,9 +5408,9 @@ begin
 
       //Indexes.
       M := CCMeta.TableReferring.Metadata as TMemDBTableMetadata;
-      CCMeta.IndexDefReferring := M.IndexByName(SelCurrent, FKMCC.IndexReferer, CCMeta.IndexDefReferringAbsIdx, pinFinalCheck);
+      CCMeta.IndexDefReferring := CCMeta.TableReferring.IndexByName(SelCurrent, FKMCC.IndexReferer, CCMeta.IndexDefReferringAbsIdx, pinFinalCheck);
       M := CCMeta.TableReferred.Metadata as TMemDBTableMetadata;
-      CCMeta.IndexDefReferred := M.IndexByName(SelCurrent, FKMCC.IndexReferred, CCMeta.IndexDefReferredAbsIdx, pinFinalCheck);
+      CCMeta.IndexDefReferred := CCMeta.TableReferred.IndexByName(SelCurrent, FKMCC.IndexReferred, CCMeta.IndexDefReferredAbsIdx, pinFinalCheck);
       //Index objs do not actually need to be the same object (copied on write),
       //and nor do they have to have the same name, or refer to the same fields,
       //but for them to be the "same" index, we expect the IndexIndex (which is AbsIndex, not NDIndex),
@@ -5162,9 +5421,9 @@ begin
 
       //Fields.
       M := CCMeta.TableReferring.Metadata as TMemDBTableMetadata;
-      CCMeta.FieldDefsReferring := M.FieldsByNames(SelCurrent, CCMeta.IndexDefReferring.FieldArray, CCMeta.FieldDefsReferringAbsIdx, pinFinalCheck);
+      CCMeta.FieldDefsReferring := CCMeta.TableReferring.FieldsByNames(SelCurrent, CCMeta.IndexDefReferring.FieldArray, CCMeta.FieldDefsReferringAbsIdx, pinFinalCheck);
       M := CCMeta.TableReferred.Metadata as TMemDBTableMetadata;
-      CCMeta.FieldDefsReferred := M.FieldsByNames(SelCurrent, CCMeta.IndexDefReferred.FieldArray, CCMeta.FieldDefsReferredAbsIdx, pinFinalCheck);
+      CCMeta.FieldDefsReferred := CCMeta.TableReferred.FieldsByNames(SelCurrent, CCMeta.IndexDefReferred.FieldArray, CCMeta.FieldDefsReferredAbsIdx, pinFinalCheck);
 
       //Expect CC meta to be as consistent as NCMeta....
       if Length(CCMeta.FieldDefsReferring) <> Length(CCMeta.FieldDefsReferred) then
@@ -5642,7 +5901,6 @@ var
   SearchRowFields: TMemRowFields;
   SearchOffsets: TFieldOffsets;
 {$ENDIF}
-  bufSel: TABSelType;
   CF, NF: TMemDbStreamable;
 begin
   //OK, so we now need to check:
@@ -5973,7 +6231,9 @@ procedure TMemDBRow.Init(Table: TMemDBTablePersistent; const Guid: TGUID);
 begin
   self.FTable := Table;
   self.FRowID := Guid;
+{$IFDEF USE_STRIPED_LOCK}
   self.FLock.Init(Guid, sizeof(Guid));
+{$ENDIF}
 end;
 
 procedure TMemDBRow.DCPHandle(const Update: TReferenceUpdate);
@@ -6456,64 +6716,14 @@ begin
   end;
 end;
 
-function TMemDBTableMetadata.FieldsByNames(const AB: TBufSelector; const Names: TMDBFieldNames; var AbsIdxs: TFieldOffsets; Reason: TPinReason): TMemFieldDefs;
-var
-  MC: TMemDbStreamable;
-  bufSel: TABSelType;
+procedure TMemDBTableMetadata.InvalidateCachedCur(const Tid: TTransactionId);
 begin
-  MC := nil;
-  case AB.SelType of
-    abCurrent: MC := self.PinCurrent(AB.TId, Reason);
-    abNext: MC := self.GetNext(AB.TId);
-    abLatest: MC := self.GetPinLatest(AB.TId, bufSel, Reason);
-  else
-    Assert(false);
-  end;
-  if AssignedNotSentinel(MC) then
-    result := FieldsByNamesInt(MC as TMemTableMetadataItem, Names, AbsIdxs)
-  else
-  begin
-    SetLength(result, 0);
-    SetLength(AbsIdxs, 0);
-  end;
+  (FEntity as TMemDBTablePersistent).InvalidateCachedCur(Tid);
 end;
 
-function TMemDbTableMetadata.FieldByName(const AB: TBufSelector; const Name: string; var AbsIndex: integer; Reason: TPinReason): TMemFieldDef;
-var
-  MC: TMemDbStreamable;
-  bufSel: TABSelType;
+procedure TMemDBTableMetadata.InvalidateCachedNxtTid(const Tid: TTransactionId);
 begin
-  MC := nil;
-  case AB.SelType of
-    abCurrent: MC := self.PinCurrent(AB.TId, Reason);
-    abNext: MC := self.GetNext(AB.TId);
-    abLatest: MC := self.GetPinLatest(AB.TId, bufSel, Reason);
-  else
-    Assert(false);
-  end;
-  if AssignedNotSentinel(MC) then
-    result := FieldByNameInt(MC as TMemTableMetadataItem, Name, AbsIndex)
-  else
-    result := nil;
-end;
-
-function TMemDBTableMetadata.IndexByName(const AB: TBufSelector; const Name: string; var AbsIndex: integer; Reason: TPinReason): TMemIndexDef;
-var
-  MC: TMemDbStreamable;
-  bufSel: TABSelType;
-begin
-  MC := nil;
-  case AB.SelType of
-    abCurrent: MC := self.PinCurrent(AB.TId, Reason);
-    abNext: MC := self.GetNext(AB.TId);
-    abLatest: MC := self.GetPinLatest(AB.TId, bufSel, Reason);
-  else
-    Assert(false);
-  end;
-  if AssignedNotSentinel(MC) then
-    result := IndexByNameInt(MC as TMemTableMetadataItem, Name, AbsIndex)
-  else
-    result := nil;
+  (FEntity as TMemDBTablePersistent).InvalidateCachedNxtTid(Tid);
 end;
 
 { TMemDBForeignKeyMetadata }
@@ -6779,12 +6989,12 @@ begin
           begin
             ProxI := EList.Items[i] as TMemDBEntityProxy;
             ObjI := ProxI.Proxy as TMemDbEntity;
-            ICur := ObjI.META_PinCurrent(Tid, pinFinalCheck);
-            INxt := ObjI.META_GetNext(Tid);
+            ICur := ObjI.Metadata.PinCurrent(Tid, pinFinalCheck);
+            INxt := ObjI.Metadata.GetNext(Tid);
             ChangeFlagsFromPinned(ICur, INxt, IAdded, IChanged, IDeleted, INull);
             if not (INull or IDeleted) then
             begin
-              ILat := ObjI.META_GetPinLatest(Tid, SelType, pinFinalCheck) as TMemEntityMetadataItem;
+              ILat := ObjI.Metadata.GetPinLatest(Tid, SelType, pinFinalCheck) as TMemEntityMetadataItem;
               Names.Add(ILat.EntityName);
             end;
           end;
@@ -7530,9 +7740,9 @@ begin
       Assert(Assigned(Proxy.Proxy) and (Proxy.Proxy is TMemDbEntity));
       Entity := Proxy.Proxy as TMemDbEntity;
       case AB.SelType of
-        abCurrent: EntMetaS := Entity.META_PinCurrent(AB.Tid, PinReason);
-        abNext: EntMetaS := Entity.META_GetNext(AB.Tid);
-        abLatest: EntMetaS := Entity.META_GetPinLatest(AB.Tid, SelType, PinReason);
+        abCurrent: EntMetaS := Entity.Metadata.PinCurrent(AB.Tid, PinReason);
+        abNext: EntMetaS := Entity.Metadata.GetNext(AB.Tid);
+        abLatest: EntMetaS := Entity.Metadata.GetPinLatest(AB.Tid, SelType, PinReason);
       else
         Assert(false);
         EntMetaS := nil;

--- a/Common/MemDB2/Test/MemDB2Test.dproj
+++ b/Common/MemDB2/Test/MemDB2Test.dproj
@@ -101,7 +101,7 @@
     <PropertyGroup Condition="'$(Cfg_1)'!=''">
         <DCC_RangeChecking>true</DCC_RangeChecking>
         <DCC_IntegerOverflowCheck>true</DCC_IntegerOverflowCheck>
-        <DCC_Define>DEBUG;USE_TRACKABLES;CHECK_TEARDOWN_REFS;DBG_UNDER_COMMIT_LOCK;$(DCC_Define)</DCC_Define>
+        <DCC_Define>DEBUG;USE_TRACKABLES;$(DCC_Define)</DCC_Define>
         <DCC_DebugDCUs>true</DCC_DebugDCUs>
         <DCC_Optimize>false</DCC_Optimize>
         <DCC_GenerateStackFrames>true</DCC_GenerateStackFrames>

--- a/Common/MemDB2/Test/MemDB2TestForm.fmx
+++ b/Common/MemDB2/Test/MemDB2TestForm.fmx
@@ -212,4 +212,13 @@ object Form1: TForm1
     Width = 80.000000000000000000
     OnClick = OOMemoryClick
   end
+  object TblModMulti: TButton
+    Height = 22.000000000000000000
+    Position.X = 360.000000000000000000
+    Position.Y = 72.000000000000000000
+    TabOrder = 23
+    Text = 'Mod 1G multi'
+    Width = 97.000000000000000000
+    OnClick = TblModMultiClick
+  end
 end

--- a/Common/MemDB2/Test/MemDB2TestForm.pas
+++ b/Common/MemDB2/Test/MemDB2TestForm.pas
@@ -32,6 +32,7 @@ type
     Label2: TLabel;
     Label3: TLabel;
     OOMemory: TButton;
+    TblModMulti: TButton;
     procedure BasicTestBtnClick(Sender: TObject);
     procedure ResetClick(Sender: TObject);
     procedure IndexTestClick(Sender: TObject);
@@ -52,6 +53,7 @@ type
     procedure WModeComboChange(Sender: TObject);
     procedure IsoComboChange(Sender: TObject);
     procedure OOMemoryClick(Sender: TObject);
+    procedure TblModMultiClick(Sender: TObject);
   private
     { Private declarations }
     FTimeStamp: TDateTime;
@@ -65,6 +67,8 @@ type
     procedure FKTestSameTable(Sender: TObject);
     procedure MultiRRTrans(Sender: TObject);
     procedure BasicTraversal(Sender: TObject);
+    procedure DropBigFKeys;
+    procedure AddBigFKeys;
   public
     { Public declarations }
   end;
@@ -179,6 +183,9 @@ const
 var
   MaxTest: integer;
   TestNum: integer;
+  Tr: TMemDBTransaction;
+  DBAPI: TMemAPIDatabase;
+  TDat: TMemAPiTableData;
 begin
   if (RMode <> amReadWriteShared) or (WMode <> amReadWriteShared) then
     LogTimeIncr('Need both modes to be amReadWriteShared. Done nothing.')
@@ -199,7 +206,10 @@ begin
           DoZombie(TestNum);
           LogtimeIncr('Zombie test, leak transaction iteration: ' +IntToStr(MaxTest)
             + ' test number: ' +IntToStr(TestNum));
-          FSession.StartTransaction(RMode, amLazyWrite, Iso);
+          //Leak both a transaction, and a bunch of API abjects.
+          Tr := FSession.StartTransaction(RMode, amLazyWrite, Iso);
+          DBAPI := TR.GetAPI;
+          TDat := DBAPI.GetAPIObjectFromEntity('Test table', APITableData) as TMemAPITableData;
         end;
       end;
       LogtimeIncr('Zombie test, reload: ' +IntToStr(MaxTest));
@@ -576,19 +586,12 @@ begin
   LogTimeIncr('Total time: ' + ElapsedToTimeStr(ElTotal));
 end;
 
-procedure TForm1.BigTblModFast;
+procedure TForm1.DropBigFKeys;
 var
   Trans: TMemDbTransaction;
   DBAPI: TMemAPIDatabase;
-  FieldIndexI: integer;
   TabI: integer;
-  TDatAPI: TMemAPITableData;
-  Found: boolean;
-  Data: TMemDBFieldDataRec;
-  TMetAPI: TMemAPITableMetadata;
-  FKAPI: TMemAPIForeignKey;
 begin
-  FTimeStamp := Now;
   Trans := FSession.StartTransaction(WMode, amLazyWrite, Iso);
   try
     DBAPI := Trans.GetAPI;
@@ -611,6 +614,68 @@ begin
     end;
   end;
   LogTimeIncr('Big table dropped FKs OK.');
+end;
+
+procedure TForm1.AddBigFKeys;
+var
+  Trans: TMemDbTransaction;
+  DBAPI: TMemAPIDatabase;
+  TabI: integer;
+  FKAPI: TMemAPIForeignKey;
+  FieldIndexI: integer;
+begin
+  Trans := FSession.StartTransaction(WMode, amLazyWrite, Iso);
+  try
+    DBAPI := Trans.GetAPI;
+    try
+      for TabI := 0 to Pred(BIG_NTABLES) do
+      begin
+        if (TabI > 0) then
+        begin
+          DBAPI.CreateForeignKey('BIGFK_'+InttoStr(TabI));
+          FKAPI := DBAPI.GetAPIObjectFromEntity('BIGFK_'+InttoStr(TabI), APIForeignKey) as TMemAPIForeignKey;
+          try
+            for FieldIndexI := 0 to Pred(BIG_NINDEXES) do
+            begin
+              FKAPI.SetReferencingChild('BIGTABLE_'+IntToStr(TabI), 'INDEX_'+IntToStr(FieldIndexI));
+              FKAPI.SetReferencedParent('BIGTABLE_'+IntToStr(TabI-1), 'INDEX_'+IntToStr(FieldIndexI));
+            end;
+          finally
+              FKAPI.Free;
+          end;
+        end;
+      end;
+    finally
+      DBAPI.Free;
+    end;
+    Trans.CommitAndFree;
+  except
+    on E: Exception do
+    begin
+      Trans.RollbackAndFree;
+      LogTimeIncr('Big table FKeys add failed' + E.Message);
+      raise;
+    end;
+  end;
+  LogTimeIncr('Big table FKeys added OK.');
+end;
+
+procedure TForm1.BigTblModFast;
+var
+  Trans: TMemDbTransaction;
+  DBAPI: TMemAPIDatabase;
+  FieldIndexI: integer;
+  TabI: integer;
+  TDatAPI: TMemAPITableData;
+  Found: boolean;
+  Data: TMemDBFieldDataRec;
+  TMetAPI: TMemAPITableMetadata;
+  FKAPI: TMemAPIForeignKey;
+begin
+  FTimeStamp := Now;
+
+  DropBigFKeys;
+
   Trans := FSession.StartTransaction(WMode, amLazyWrite, Iso);
   try
     DBAPI := Trans.GetAPI;
@@ -705,40 +770,8 @@ begin
     end;
   end;
   LogTimeIncr('Big table indexes added OK.');
-  Trans := FSession.StartTransaction(WMode, amLazyWrite, Iso);
-  try
-    DBAPI := Trans.GetAPI;
-    try
-      for TabI := 0 to Pred(BIG_NTABLES) do
-      begin
-        if (TabI > 0) then
-        begin
-          DBAPI.CreateForeignKey('BIGFK_'+InttoStr(TabI));
-          FKAPI := DBAPI.GetAPIObjectFromEntity('BIGFK_'+InttoStr(TabI), APIForeignKey) as TMemAPIForeignKey;
-          try
-            for FieldIndexI := 0 to Pred(BIG_NINDEXES) do
-            begin
-              FKAPI.SetReferencingChild('BIGTABLE_'+IntToStr(TabI), 'INDEX_'+IntToStr(FieldIndexI));
-              FKAPI.SetReferencedParent('BIGTABLE_'+IntToStr(TabI-1), 'INDEX_'+IntToStr(FieldIndexI));
-            end;
-          finally
-              FKAPI.Free;
-          end;
-        end;
-      end;
-    finally
-      DBAPI.Free;
-    end;
-    Trans.CommitAndFree;
-  except
-    on E: Exception do
-    begin
-      Trans.RollbackAndFree;
-      LogTimeIncr('Big table FKeys add failed' + E.Message);
-      raise;
-    end;
-  end;
-  LogTimeIncr('Big table FKeys added OK.');
+
+  AddBigFKeys;
 end;
 
 procedure TForm1.BigTblModSlow;
@@ -830,6 +863,197 @@ begin
   LogTimeIncr('DB started...');
   FSession := FDB.StartSession;
   LogTimeIncr('Session running.');
+end;
+
+type
+  TMultiModThread = class(TThread)
+    FIndex: integer;
+    FByTable: boolean;
+    FParent: TForm1;
+    FExcept: boolean;
+    FMsg: string;
+    procedure Execute; override;
+    procedure ModByTable;
+    procedure ModByRow;
+  end;
+
+procedure TMultiModThread.Execute;
+begin
+  if FByTable then
+    ModByTable
+  else
+    ModByRow;
+end;
+
+procedure TMultiModThread.ModByRow;
+var
+  Trans: TMemDBTransaction;
+  DBAPI: TMemAPIDatabase;
+  TabI, RowI: integer;
+  TDatAPI: TMemAPITableData;
+  Found: boolean;
+  FieldIndexI: integer;
+  Data: TMemDBFieldDataRec;
+begin
+  Trans := FSession.StartTransaction(FParent.WMode, amLazyWrite, FParent.Iso);
+  try
+    DBAPI := Trans.GetAPI;
+    try
+      for TabI := 0 to Pred(BIG_NTABLES) do
+      begin
+        TDatAPI := DBAPI.GetAPIObjectFromEntity('BIGTABLE_'+IntToStr(TabI), APITableData) as TMemAPITableData;
+        try
+          RowI := 0;
+          Found:= TDatAPI.Locate(ptFirst, '');
+          while Found do
+          begin
+            if (RowI mod BIG_NTABLES) = FIndex then
+            begin
+              for FieldIndexI := 0 to Pred(BIG_NINDEXES) do
+              begin
+                TDatAPI.ReadField('FIELD_'+InttoStr(FieldIndexI), Data);
+                Assert(Data.FieldType = ftInteger);
+                Data.i32Val := Data.i32Val + 10 * BIG_ROWS;
+                TDatAPI.WriteField('FIELD_'+InttoStr(FieldIndexI), Data);
+              end;
+              TDatAPI.Post;
+            end;
+            Found:= TDatAPI.Locate(ptNext, '');
+            Inc(RowI);
+          end;
+          Assert(RowI = BIG_ROWS);
+        finally
+          TDatAPI.Free;
+        end;
+      end;
+    finally
+      DBAPI.Free;
+    end;
+    Trans.CommitAndFree;
+  except
+    on E: Exception do
+    begin
+      Trans.RollbackAndFree;
+      FExcept := true;
+      FMsg := E.Message;
+    end;
+  end;
+end;
+
+procedure TMultiModThread.ModByTable;
+var
+  Trans: TMemDBTransaction;
+  DBAPI: TMemAPIDatabase;
+  TabI: integer;
+  TDatAPI: TMemAPITableData;
+  Found: boolean;
+  FieldIndexI: integer;
+  Data: TMemDBFieldDataRec;
+begin
+  Trans := FSession.StartTransaction(FParent.WMode, amLazyWrite, FParent.Iso);
+  try
+    DBAPI := Trans.GetAPI;
+    try
+      TDatAPI := DBAPI.GetAPIObjectFromEntity('BIGTABLE_'+IntToStr(FIndex), APITableData) as TMemAPITableData;
+      try
+        Found:= TDatAPI.Locate(ptFirst, '');
+        while Found do
+        begin
+          for FieldIndexI := 0 to Pred(BIG_NINDEXES) do
+          begin
+            TDatAPI.ReadField('FIELD_'+InttoStr(FieldIndexI), Data);
+            Assert(Data.FieldType = ftInteger);
+            Data.i32Val := Data.i32Val * 2;
+            TDatAPI.WriteField('FIELD_'+InttoStr(FieldIndexI), Data);
+          end;
+          TDatAPI.Post;
+          Found:= TDatAPI.Locate(ptNext, '');
+        end;
+      finally
+        TDatAPI.Free;
+      end;
+    finally
+      DBAPI.Free;
+    end;
+    Trans.CommitAndFree;
+  except
+    on E: Exception do
+    begin
+      Trans.RollbackAndFree;
+      FExcept := true;
+      FMsg := E.Message;
+    end;
+  end;
+end;
+
+procedure TForm1.TblModMultiClick(Sender: TObject);
+
+  procedure BigTblModGeneric(ByTable: boolean);
+  var
+    Threads: array of TMultiModThread;
+    TabI: integer;
+  begin
+    SetLength(Threads, BIG_NTABLES);
+    for TabI := 0 to Pred(BIG_NTABLES) do
+    begin
+      Threads[TabI] := TMultiModThread.Create(true) as TMultiModThread;
+      with Threads[TabI] do
+      begin
+        FIndex := TabI;
+        FByTable := ByTable;
+        FParent := self;
+        Resume;
+      end;
+    end;
+    for TabI := 0 to Pred(BIG_NTABLES) do
+      with Threads[TabI] do
+      begin
+        WaitFor;
+        if FExcept then
+          LogtimeIncr('A worker thread raised an exception (' + FMsg + ')');
+        Free;
+      end;
+  end;
+
+  procedure BigTblModMultiByTable;
+  begin
+    BigTblModGeneric(true);
+  end;
+
+  procedure BigTblModMultiByRow;
+  begin
+    BigTblModGeneric(false);
+  end;
+
+var
+  Start, N, ElFast, ElSlow: double;
+begin
+  if (WMode <> amReadWriteShared) then
+  begin
+    LogTimeIncr('Need write mode to be amReadWriteShared. Done nothing.');
+    exit;
+  end;
+  if (Iso >= ilSnapshot) then
+  begin
+    LogTimeIncr('Need iso to be < ilSnapshot (for row ordering). Done nothing.');
+    exit;
+  end;
+
+  FTimeStamp := Now;
+  LogTimeIncr('This will take a moment (comparing different methods)...');
+  Application.ProcessMessages;
+  Start := Now;
+  DropBigFKeys;
+  BigTblModMultiByTable;
+  LogTimeIncr('...');
+  AddBigFKeys;
+  N := Now;
+  ElFast := N - Start;
+  Start := N;
+  BigTblModMultiByRow;
+  ElSlow := Now - Start;
+  LogTimeIncr('Total time (one thread per table): ' + ElapsedToTimeStr(ElFast));
+  LogTimeIncr('Total time (threads interleaving rows): ' + ElapsedToTimeStr(ElSlow));
 end;
 
 procedure TForm1.TstBlobsClick(Sender: TObject);

--- a/Common/Parallelizer/Parallelizer.pas
+++ b/Common/Parallelizer/Parallelizer.pas
@@ -61,7 +61,7 @@ uses
 
 const
   S_UNEXPECTED_WAIT_RET = 'Unexpected return from parallel wait: ';
-  S_FWD_EXCEPTION = 'Exception forwaded between threads (untranslated): ';
+  S_FWD_EXCEPTION = 'Exception forwarded between threads (untranslated): ';
 
 type
   TParallelHandlerThread = class(TThread)

--- a/Overall TODO.txt
+++ b/Overall TODO.txt
@@ -1,13 +1,7 @@
 
 MemDB2 TODO.
 
-- Refactor META_ / Pinning functions to use cached values.
-  - Todo: Debug bad multi-reader performance, see if this is indeed the cause.
-
-  Change "big table" tests to:
-  - Assign different threads to mod different tables.
-  - Assign different threads to mod odd / even rows :-)
-    - Should improve performance despite locking once made mods above.
+- OK. That's all the optimizations I can think of for the moment.
 
 - Any other optimizations you can think of.
 


### PR DESCRIPTION
Misc: Update TODO.
MemDB2: Add ISO check for parallel write tests.
MemDB2: Fix spelling error.
MemDB2: MetaCaching by copy.
MemDB2: Metadata caching by reference.
MemDB2: OK. APITableData cached metadata access, now to remove the cruft I put in.
MemDB2: Back to using TinyLock, with a more social implementation.